### PR TITLE
Introduced Node/NodeListener classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ dependencies {
 	compile group : 'org.slf4j', name : 'slf4j-log4j12', version: '1.7.6'
 	compile group : 'log4j', name : 'log4j', version: '1.2.17'
 	compile group : 'com.oracle.tools', name : 'oracle-tools-runtime', version: '1.2.1'
+	compile group : 'com.oracle.tools', name : 'oracle-tools-core', version: '1.2.1'
+	compile group : 'com.oracle.tools', name : 'oracle-tools-testing-support', version: '1.2.1'
 	testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 

--- a/src/main/java/xdzk/ZooKeeperStandalone.java
+++ b/src/main/java/xdzk/ZooKeeperStandalone.java
@@ -6,7 +6,11 @@ import com.oracle.tools.runtime.java.NativeJavaApplicationBuilder;
 import com.oracle.tools.runtime.java.SimpleJavaApplication;
 import com.oracle.tools.runtime.java.SimpleJavaApplicationSchema;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.UUID;
 
 /**
  * Utility class to launch a stand alone (non clustered)
@@ -44,24 +48,69 @@ public class ZooKeeperStandalone {
 
 	/**
 	 * Launch the {@link org.apache.zookeeper.ZooKeeperMain} class in
-	 * a separate JVM.
+	 * a separate JVM. The executing thread is blocked until a socket
+	 * connection can be established with the ZooKeeper server.
+	 *
+	 * @throws InterruptedException
 	 */
-	public synchronized static void start() {
+	public synchronized static void start() throws InterruptedException {
 		if (application == null) {
 			String classpath = System.getProperty("java.class.path");
 			SimpleJavaApplicationSchema schema =
 					new SimpleJavaApplicationSchema("org.apache.zookeeper.server.ZooKeeperServerMain", classpath)
 							.setArgument(String.valueOf(PORT))
-							.setArgument(System.getProperty("java.io.tmpdir"));
+							.setArgument(System.getProperty("java.io.tmpdir") + File.pathSeparator + UUID.randomUUID());
 
 			NativeJavaApplicationBuilder<SimpleJavaApplication, SimpleJavaApplicationSchema> builder =
 					new NativeJavaApplicationBuilder<>();
 
 			try {
 				application = builder.realize(schema, "ZooKeeper Server", new SystemApplicationConsole());
+				waitForServer();
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
+		}
+	}
+
+	/**
+	 * Block the executing thread until a socket connection can be established
+	 * with the ZooKeeper server.
+	 *
+	 * @throws InterruptedException
+	 */
+	private static void waitForServer() throws InterruptedException {
+		boolean canConnect = false;
+		int tries = 0;
+		Socket socket = null;
+
+		do {
+			try {
+				Thread.sleep(10);
+				socket = new Socket();
+				socket.connect(new InetSocketAddress("localhost", PORT));
+				canConnect = true;
+				socket.close();
+				socket = null;
+			}
+			catch (IOException e) {
+				// ignore
+			}
+			finally {
+				if (socket != null) {
+					try {
+						socket.close();
+					}
+					catch (IOException e) {
+						// ignore
+					}
+				}
+			}
+		}
+		while ((!canConnect) && tries < 10);
+
+		if (!canConnect) {
+			throw new IllegalStateException("Cannot connect to ZooKeeper server");
 		}
 	}
 

--- a/src/main/java/xdzk/ZooKeeperStandalone.java
+++ b/src/main/java/xdzk/ZooKeeperStandalone.java
@@ -6,6 +6,7 @@ import com.oracle.tools.runtime.java.NativeJavaApplicationBuilder;
 import com.oracle.tools.runtime.java.SimpleJavaApplication;
 import com.oracle.tools.runtime.java.SimpleJavaApplicationSchema;
 
+import javax.net.SocketFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -86,9 +87,9 @@ public class ZooKeeperStandalone {
 
 		do {
 			try {
-				Thread.sleep(10);
-				socket = new Socket();
-				socket.connect(new InetSocketAddress("localhost", PORT));
+				Thread.sleep(100);
+				socket = SocketFactory.getDefault().createSocket();
+				socket.connect(new InetSocketAddress("localhost", PORT), 5000);
 				canConnect = true;
 				socket.close();
 				socket = null;
@@ -107,7 +108,7 @@ public class ZooKeeperStandalone {
 				}
 			}
 		}
-		while ((!canConnect) && tries < 10);
+		while ((!canConnect) && tries < 100);
 
 		if (!canConnect) {
 			throw new IllegalStateException("Cannot connect to ZooKeeper server");

--- a/src/main/java/zk/node/Node.java
+++ b/src/main/java/zk/node/Node.java
@@ -1,0 +1,260 @@
+package zk.node;
+
+
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Representation of a ZooKeeper node with the following features:
+ * <ul>
+ *     <li>Maintains a cache of children nodes</li>
+ *     <li>Allows for the registration of {@link zk.node.NodeListener NodeListeners}
+ *         that are notified upon the addition and removal of child nodes</li>
+ * </ul>
+ * Instances must be initialized prior to usage. Idiomatic construction
+ * of this object is as such:
+ * <pre>
+ *     Node node = new Node(client, path).init();
+ * </pre>
+ *
+ * @author Patrick Peralta
+ */
+public class Node {
+	private static final Logger LOG = LoggerFactory.getLogger(Node.class);
+
+	/**
+	 * ZooKeeper client.
+	 */
+	private final ZooKeeper client;
+
+	/**
+	 * Absolute path for this node.
+	 */
+	private final String path;
+
+	/**
+	 * Watcher instance that is notified when children are added/removed
+	 * from this node.
+	 */
+	private final ChildWatcher childWatcher = new ChildWatcher();
+
+	/**
+	 * Callback instance that is invoked to process the result
+	 * of {@link org.apache.zookeeper.ZooKeeper#getChildren}.
+	 *
+	 * @see #watchChildren
+	 */
+	private final ChildCallback childCallback = new ChildCallback();
+
+	/**
+	 * Cache of children for this node.
+	 */
+	private volatile Set<String> cache = Collections.emptySet();
+
+	/**
+	 * Set of {@link zk.node.NodeListener NodeListeners} to be notified
+	 * when children are added/removed from this node.
+	 */
+	private final Set<NodeListener> listeners = new CopyOnWriteArraySet<>();
+
+
+	/**
+	 * Construct a Node.
+	 * <p>
+	 * Note that {@link #init} must be invoked prior to usage. Consider
+	 * the following pattern for construction:
+	 * <pre>
+	 *     Node node = new Node(client, path).init();
+	 * </pre>
+	 *
+	 * @param client  ZooKeeper client
+	 * @param path    absolute path for this node
+	 */
+	public Node(ZooKeeper client, String path) {
+		this.path = path;
+		this.client = client;
+	}
+
+	/**
+	 * Initialize this node. Initialization consists of the following:
+	 * <ul>
+	 *     <li>Ensure that the full path exists in ZooKeeper</li>
+	 *     <li>Invoke {@link org.apache.zookeeper.ZooKeeper#getChildren}
+	 *         in order to populate the cache and register the watch</li>
+	 * </ul>
+	 *
+	 * @return this object
+	 *
+	 * @throws InterruptedException
+	 */
+	public Node init() throws InterruptedException {
+		try {
+			if (client.exists(path, false) == null) {
+				String traversed = "/";
+				String p = this.path;
+				if (p.startsWith("/")) {
+					p = p.substring(1);
+				}
+				String[] nodes = p.split("/");
+				for (String node : nodes) {
+					String current = traversed + node;
+					if (client.exists(current, false) == null) {
+						client.create(current, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+					}
+					traversed = current + "/";
+				}
+			}
+		}
+		catch (KeeperException.NodeExistsException e) {
+			// Assume this means that another member of the cluster
+			// is creating the same path
+		}
+		catch (KeeperException e) {
+			throw new RuntimeException(e);
+		}
+
+		watchChildren();
+
+		return this;
+	}
+
+	/**
+	 * Return the cached set of children for this node.
+	 *
+	 * @return set of children for this node
+	 */
+	public Set<String> getChildren() {
+		return cache;
+	}
+
+	/**
+	 * Force a refresh of children for this node. This method
+	 * updates the cache and returns the latest set of children.
+	 *
+	 * @return refreshed set of children for this node
+	 *
+	 * @throws InterruptedException
+	 */
+	public Set<String> refreshChildren() throws InterruptedException {
+		CountDownLatch latch = new CountDownLatch(1);
+		client.getChildren(path, childWatcher, childCallback, latch);
+		latch.await();
+		return cache;
+	}
+
+	/**
+	 * Add a {@link zk.node.NodeListener} to this node.
+	 *
+	 * @param listener node listener to add
+	 */
+	public void addListener(NodeListener listener) {
+		listeners.add(listener);
+	}
+
+	/**
+	 * Remove the indicated {@link zk.node.NodeListener}
+	 * from this node.
+	 *
+	 * @param listener node listener to remove
+	 */
+	public void removeListener(NodeListener listener) {
+		listeners.remove(listener);
+	}
+
+	/**
+	 * Asynchronously update the cache of children for this node.
+	 * This also registers a watch that will be triggered when
+	 * children are added/removed from this node.
+	 */
+	protected void watchChildren() {
+		client.getChildren(path, childWatcher, childCallback, null);
+	}
+
+	/**
+	 * Watcher implementation for the children of this node.
+	 */
+	class ChildWatcher implements Watcher {
+
+		@Override
+		public void process(WatchedEvent event) {
+			watchChildren();
+		}
+	}
+
+	/**
+	 * Callback implementation that is invoked to process the result
+	 * of {@link org.apache.zookeeper.ZooKeeper#getChildren} for this node.
+	 */
+	class ChildCallback implements AsyncCallback.ChildrenCallback {
+
+		/**
+		 * {@inheritDoc}
+		 * <p>
+		 * This callback implementation does the following:
+		 * <ul>
+		 *     <li>Updates the {@link #cache} of children</li>
+		 *     <li>Fires events to the registered {@link zk.node.NodeListener NodeListeners}</li>
+		 * </ul>
+		 */
+		@Override
+		public void processResult(int rc, String path, Object ctx, List<String> children) {
+			LOG.debug(">>> path: {}, children: {}", path, children);
+			Set <String> arrived = new HashSet<>();
+			Set <String> departed = new HashSet<>();
+			if (children == null) {
+				children = Collections.emptyList();
+			}
+
+			for (String child : children) {
+				if (!cache.contains(child)) {
+					arrived.add(child);
+				}
+			}
+
+			Set<String> newChildren = Collections.unmodifiableSet(new HashSet<>(children));
+			for (String child : cache) {
+				if (!newChildren.contains(child)) {
+					departed.add(child);
+				}
+			}
+
+			cache = newChildren;
+
+			LOG.debug("New:      {}", arrived);
+			LOG.debug("Departed: {}", departed);
+			LOG.debug("All:      {}", cache);
+
+			if (arrived.isEmpty() && departed.isEmpty()) {
+				return;
+			}
+
+			for (NodeListener listener : listeners) {
+				if (!arrived.isEmpty()) {
+					listener.onChildrenAdded(Collections.unmodifiableSet(arrived));
+				}
+				if (!departed.isEmpty()) {
+					listener.onChildrenRemoved(Collections.unmodifiableSet(departed));
+				}
+			}
+
+			if (ctx instanceof CountDownLatch) {
+				((CountDownLatch) ctx).countDown();
+			}
+		}
+	}
+
+}

--- a/src/main/java/zk/node/NodeListener.java
+++ b/src/main/java/zk/node/NodeListener.java
@@ -1,0 +1,28 @@
+package zk.node;
+
+import java.util.Set;
+
+/**
+ * Callback interface for receiving notifications of additions and
+ * removals of node children.
+ *
+ * @see Node#addListener
+ * @see Node#removeListener
+ *
+ * @author Patrick Peralta
+ */
+public interface NodeListener {
+	/**
+	 * Invoked upon the addition of children to a {@link Node}.
+	 *
+	 * @param children set of children added to a node
+	 */
+	void onChildrenAdded(Set<String> children);
+
+	/**
+	 * Invoked upon the removal of children from a {@link Node}.
+	 *
+	 * @param children set of children removed from a node
+	 */
+	void onChildrenRemoved(Set<String> children);
+}

--- a/src/test/java/xdzk/AdminContainerObserverTest.java
+++ b/src/test/java/xdzk/AdminContainerObserverTest.java
@@ -1,0 +1,168 @@
+package xdzk;
+
+
+import com.oracle.tools.deferred.Eventually;
+import com.oracle.tools.runtime.console.SystemApplicationConsole;
+import com.oracle.tools.runtime.java.JavaApplication;
+import com.oracle.tools.runtime.java.NativeJavaApplicationBuilder;
+import com.oracle.tools.runtime.java.SimpleJavaApplication;
+import com.oracle.tools.runtime.java.SimpleJavaApplicationSchema;
+import com.oracle.tools.util.CompletionListener;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.oracle.tools.deferred.DeferredHelper.eventually;
+import static com.oracle.tools.deferred.DeferredHelper.invoking;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Test to assert the ability of {@link xdzk.AdminServer} to observe
+ * the number of {@link xdzk.ContainerServer} instances in a cluster.
+ *
+ * @author Patrick Peralta
+ */
+public class AdminContainerObserverTest {
+	/**
+	 * Logger.
+	 */
+	private static final Logger LOG = LoggerFactory.getLogger(AdminContainerObserverTest.class);
+
+	/**
+	 * Launch the given class's {@code main} method in a separate JVM.
+	 *
+	 * @param clz class to launch
+	 *
+	 * @return launched application
+	 *
+	 * @throws IOException
+	 */
+	protected JavaApplication<SimpleJavaApplication> launch(Class clz) throws IOException {
+		return launch(clz, null);
+	}
+
+	/**
+	 * Launch the given class's {@code main} method in a separate JVM.
+	 *
+	 * @param clz class to launch
+	 * @param args command line arguments
+	 *
+	 * @return launched application
+	 *
+	 * @throws IOException
+	 */
+	protected JavaApplication<SimpleJavaApplication> launch(Class clz, String[] args) throws IOException {
+		String classpath = System.getProperty("java.class.path");
+		SimpleJavaApplicationSchema schema = new SimpleJavaApplicationSchema(clz.getName(), classpath);
+		if (args != null) {
+			for (String arg : args) {
+				schema.addArgument(arg);
+			}
+		}
+		NativeJavaApplicationBuilder<SimpleJavaApplication, SimpleJavaApplicationSchema> builder =
+				new NativeJavaApplicationBuilder<>();
+		return builder.realize(schema, clz.getName(), new SystemApplicationConsole());
+	}
+
+	/**
+	 * Return the set of containers known to the given admin server.
+	 *
+	 * @param adminServer admin server application
+	 *
+	 * @return set of containers known to the admin server
+	 *
+	 * @throws Exception
+	 */
+	public Set<String> getCurrentContainers(JavaApplication<SimpleJavaApplication> adminServer) throws Exception {
+		final Set<String> containers = Collections.synchronizedSet(new HashSet<String>());
+		final CountDownLatch latch = new CountDownLatch(1);
+		final AtomicReference<Exception> exception = new AtomicReference<>();
+
+		adminServer.submit(new AdminServer.CurrentContainers(), new CompletionListener<Collection<String>>() {
+			@Override
+			public void onCompletion(Collection<String> result) {
+				containers.addAll(result);
+				latch.countDown();
+			}
+
+			@Override
+			public void onException(Exception e) {
+				exception.set(e);
+				latch.countDown();
+			}
+		});
+
+		if (latch.await(10, TimeUnit.SECONDS)) {
+			if (exception.get() != null) {
+				throw exception.get();
+			}
+			return containers;
+		}
+		else {
+			throw new TimeoutException();
+		}
+	}
+
+	/**
+	 * Execute the following sequence:
+	 * <ol>
+	 *     <li>Launch a ZooKeeper standalone server</li>
+	 *     <li>Launch an {@link xdzk.AdminServer}</li>
+	 *     <li>Launch 3 instances of {@link xdzk.ContainerServer}</li>
+	 *     <li>Assert that the admin server sees 3 containers</li>
+	 *     <li>Shut down a container</li>
+	 *     <li>Assert that the admin server sees 2 containers</li>
+	 * </ol>
+	 * @throws Exception
+	 */
+	@Test
+	public void test() throws Exception {
+		JavaApplication<SimpleJavaApplication> adminServer = null;
+		JavaApplication<SimpleJavaApplication> container1 = null;
+		JavaApplication<SimpleJavaApplication> container2 = null;
+		JavaApplication<SimpleJavaApplication> container3 = null;
+
+		try {
+			ZooKeeperStandalone.start();
+			adminServer = launch(AdminServer.class);
+			container1 = launch(ContainerServer.class);
+			container2 = launch(ContainerServer.class);
+			container3 = launch(ContainerServer.class);
+
+			Eventually.assertThat(eventually(invoking(this).getCurrentContainers(adminServer).size()), is(3));
+
+			container3.close();
+			container3 = null;
+
+			Eventually.assertThat(eventually(invoking(this).getCurrentContainers(adminServer).size()), is(2));
+		}
+
+		finally {
+			if (adminServer != null) {
+				adminServer.close();
+			}
+			if (container1 != null) {
+				container1.close();
+			}
+			if (container2 != null) {
+				container2.close();
+			}
+			if (container3 != null) {
+				container3.close();
+			}
+			ZooKeeperStandalone.stop();
+		}
+	}
+
+}

--- a/src/test/java/zk/node/NodeTest.java
+++ b/src/test/java/zk/node/NodeTest.java
@@ -1,0 +1,123 @@
+package zk.node;
+
+import com.oracle.tools.deferred.Eventually;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import xdzk.ZooKeeperStandalone;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.oracle.tools.deferred.DeferredHelper.eventually;
+import static com.oracle.tools.deferred.DeferredHelper.invoking;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Patrick Peralta
+ */
+public class NodeTest {
+	private static final Logger LOG = LoggerFactory.getLogger(NodeTest.class);
+
+	private static final String CONNECT_STRING = "localhost:" + ZooKeeperStandalone.PORT;
+
+	@BeforeClass
+	public static void startZooKeeper() throws InterruptedException {
+		ZooKeeperStandalone.start();
+	}
+
+	@AfterClass
+	public static void stopZooKeeper() {
+		ZooKeeperStandalone.stop();
+	}
+
+	/**
+	 * Create a ZooKeeper client. The executing thread blocks until
+	 * the connection is made to the server and the client is usable.
+	 *
+	 * @return a ZooKeeper client
+	 *
+	 * @throws InterruptedException
+	 */
+	protected ZooKeeper createClient() throws InterruptedException, TimeoutException {
+		try {
+			final CountDownLatch latch = new CountDownLatch(1);
+
+			ZooKeeper client = new ZooKeeper(CONNECT_STRING, 2000, new Watcher() {
+				@Override
+				public void process(WatchedEvent event) {
+					LOG.info("ZooKeeper event: {}", event);
+					if (event.getState() == Event.KeeperState.SyncConnected) {
+						latch.countDown();
+					}
+				}
+			});
+			if (latch.await(10, TimeUnit.SECONDS)) {
+				return client;
+			}
+			else {
+				throw new TimeoutException("Could not connect to ZooKeeper server");
+			}
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * todo: double check method name and add doc
+	 * @throws Exception
+	 */
+	@Test
+	public void testNode() throws Exception {
+		ZooKeeper client = createClient();
+		String path = "/test";
+
+		try {
+			final Set<String> added = Collections.synchronizedSet(new HashSet<String>());
+			final Set<String> removed = Collections.synchronizedSet(new HashSet<String>());
+			Node node = new Node(client, path).init();
+			node.addListener(new NodeListener() {
+				@Override
+				public void onChildrenAdded(Set<String> children) {
+					added.addAll(children);
+				}
+
+				@Override
+				public void onChildrenRemoved(Set<String> children) {
+					removed.addAll(children);
+				}
+			});
+			client.create(path + "/1", null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+			client.create(path + "/2", null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+			client.create(path + "/3", null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+			client.create(path + "/4", null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+			client.delete(path + "/2", -1);
+			client.delete(path + "/4", -1);
+
+			Eventually.assertThat(eventually(invoking(node).getChildren()), hasItems("1", "3"));
+			assertThat(added, hasItems("1", "2", "3", "4"));
+			assertThat(removed, hasItems("2", "4"));
+		}
+		finally {
+			for (String s : client.getChildren(path, false)) {
+				client.delete(path + '/' + s, -1);
+			}
+			client.delete(path, -1);
+			client.close();
+		}
+	}
+}


### PR DESCRIPTION
Added a Node class that provides functionality
for obtaining children and receiving notifications
of child additions and removals.

Improved ZooKeeperStandalone to guarantee that
ZK is running before returning from the start
method.

First usage of Oracle Tools Eventually.assertThat.
See the following reference for details:

http://coherence-community.github.io/oracle-tools/1.2.1/core/deferreds.html

Refactored ContainerServer to use Node and NodeListener
