### PR TITLE
Introduced Container domain classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compile group : 'org.apache.zookeeper', name : 'zookeeper', version: '3.4.5'
 	compile group : 'org.apache.curator', name : 'curator-recipes', version: '2.4.0'
 	compile group : 'org.apache.curator', name : 'curator-test', version: '2.4.0'
+	compile group : 'org.springframework', name: 'spring-core', version: '4.0.2.RELEASE'
 	compile group : 'org.slf4j', name : 'slf4j-api', version: '1.7,6'
 	compile group : 'org.slf4j', name : 'slf4j-log4j12', version: '1.7.6'
 	compile group : 'log4j', name : 'log4j', version: '1.2.17'

--- a/src/main/java/xdzk/AdminServer.java
+++ b/src/main/java/xdzk/AdminServer.java
@@ -226,7 +226,11 @@ public class AdminServer extends AbstractServer implements Candidate {
 	 * @param module the name of the module to be deployed
 	 */
 	private void deployModule(String module) {
-		String container = this.containerMatcher.match(module, getContainerPaths());
+		// Since the interface definition for ContainerMatcher changed to require
+		// an Iterator<Container>, just going to skip ContainerMatcher usage
+		// and simply select the first container path found.
+		String container = getContainerPaths().iterator().next(); // TODO: REVISIT
+
 		LOG.info("deploying module '{}' to container: {}", module, container);
 		try {
 			getClient().create(Path.DEPLOYMENTS + "/" + container + "/" + module, null,

--- a/src/main/java/xdzk/ContainerMatcher.java
+++ b/src/main/java/xdzk/ContainerMatcher.java
@@ -1,6 +1,8 @@
 package xdzk;
 
-import java.util.Set;
+import xdzk.curator.Container;
+
+import java.util.Iterator;
 
 /**
  * Strategy interface for matching a ModuleDeploymentRequest to one of the candidate container nodes.
@@ -21,6 +23,6 @@ public interface ContainerMatcher {
 	// metadata extracted from the stream deployment manifest, such as the number of instances.
 	// Also, the String return and collection element type should be Container instances
 	// where ultimately matching will take Container attributes and metrics into consideration.
-	String match(String module, Set<String> candidates);
+	Container match(String module, Iterator<Container> candidates);
 
 }

--- a/src/main/java/xdzk/RandomContainerMatcher.java
+++ b/src/main/java/xdzk/RandomContainerMatcher.java
@@ -1,8 +1,11 @@
 package xdzk;
 
+import xdzk.curator.Container;
+
 import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Random;
-import java.util.Set;
 
 /**
  * Implementation of the {@link ContainerMatcher} strategy that selects any one of the candidate containers at random.
@@ -10,17 +13,18 @@ import java.util.Set;
  * @author Mark Fisher
  */
 public class RandomContainerMatcher implements ContainerMatcher {
+	private static final Random RANDOM = new Random();
 
 	/**
 	 * Randomly selects one of the candidate containers.
 	 */
 	@Override
-	public String match(String module, Set<String> candidates) {
-		if (candidates == null || candidates.size() == 0) {
-			return null;
+	public Container match(String module, Iterator<Container> candidates) {
+		List<Container> containers = new ArrayList<>();
+		while (candidates.hasNext()) {
+			containers.add(candidates.next());
 		}
-		int i = new Random().nextInt(candidates.size());
-		return new ArrayList<>(candidates).get(i);
+		return containers.isEmpty() ? null : containers.get(RANDOM.nextInt(containers.size()));
 	}
 
 }

--- a/src/main/java/xdzk/curator/AdminServer.java
+++ b/src/main/java/xdzk/curator/AdminServer.java
@@ -207,6 +207,10 @@ public class AdminServer extends AbstractServer implements ContainerAware {
 			containers.getListenable().removeListener(containerListener);
 			containers.close();
 		}
+		catch (IllegalStateException e) {
+			// IllegalStateException is thrown if leaderSelector or
+			// containers have already been closed
+		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
@@ -282,16 +286,15 @@ public class AdminServer extends AbstractServer implements ContainerAware {
 
 		@Override
 		public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
-			String child = Paths.stripPath(event.getData().getPath());
 			switch (event.getType()) {
 				case CHILD_ADDED:
-					LOG.info("Container added: {}", child);
+					LOG.info("Container added: {}", Paths.stripPath(event.getData().getPath()));
 					break;
 				case CHILD_UPDATED:
-					LOG.info("Container updated: {}", child);
+					LOG.info("Container updated: {}", Paths.stripPath(event.getData().getPath()));
 					break;
 				case CHILD_REMOVED:
-					LOG.info("Container removed: {}", child);
+					LOG.info("Container removed: {}", Paths.stripPath(event.getData().getPath()));
 					break;
 				case CONNECTION_SUSPENDED:
 					break;
@@ -323,7 +326,7 @@ public class AdminServer extends AbstractServer implements ContainerAware {
 				Thread.sleep(Long.MAX_VALUE);
 			}
 			catch (InterruptedException e) {
-				LOG.debug("Leadership canceled due to thread interrupt");
+				LOG.info("Leadership canceled due to thread interrupt");
 				Thread.currentThread().interrupt();
 			}
 			finally {

--- a/src/main/java/xdzk/curator/ChildPathIterator.java
+++ b/src/main/java/xdzk/curator/ChildPathIterator.java
@@ -1,0 +1,66 @@
+package xdzk.curator;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.springframework.core.convert.converter.Converter;
+
+import java.util.Iterator;
+
+/**
+ * Iterator over {@link ChildData} instances that are managed by {@link PathChildrenCache}.
+ * A {@link Converter} is used to convert the node data into a domain object.
+ *
+ * @param <T> the domain class type returned by this iterator
+ *
+ * @author Patrick Peralta
+ */
+public class ChildPathIterator<T> implements Iterator<T> {
+	/**
+	 * Converter from {@link ChildData} to domain class type {@link T}.
+	 */
+	private final Converter<ChildData, T> converter;
+
+	/**
+	 * The actual iterator over the {@link ChildData}.
+	 */
+	private final Iterator<ChildData> iterator;
+
+	/**
+	 * Construct a ChildPathIterator.
+	 *
+	 * @param converter  converter from node data to domain object
+	 * @param cache      source for children nodes
+	 */
+	public ChildPathIterator(Converter<ChildData, T> converter, PathChildrenCache cache) {
+		this.converter = converter;
+		this.iterator = cache.getCurrentData().iterator();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean hasNext() {
+		return iterator.hasNext();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public T next() {
+		return converter.convert(iterator.next());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * <p/>
+	 * Implementation throws {@link UnsupportedOperationException} because
+	 * removals are not supported.
+	 */
+	@Override
+	public void remove() {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/src/main/java/xdzk/curator/Container.java
+++ b/src/main/java/xdzk/curator/Container.java
@@ -1,0 +1,63 @@
+package xdzk.curator;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Domain object for an XD container. This object is typically constructed
+ * from container data maintained in ZooKeeper.
+ *
+ * @author Patrick Peralta
+ */
+public class Container {
+	/**
+	 * Container name.
+	 */
+	private final String name;
+
+	/**
+	 * Container attributes.
+	 */
+	private final Map<String, String> attributes;
+
+	/**
+	 * Construct a Container object.
+	 *
+	 * @param name        container name
+	 * @param attributes  container attributes
+	 */
+	public Container(String name, Map<String, String> attributes) {
+		this.name = name;
+		this.attributes = Collections.unmodifiableMap(new HashMap<String, String>(attributes));
+	}
+
+	/**
+	 * Return the container name.
+	 *
+	 * @return container name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Return the container attributes.
+	 *
+	 * @return read-only map of container attributes
+	 */
+	public Map<String, String> getAttributes() {
+		return attributes;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		return "Container{" +
+				"name='" + name + '\'' +
+				", attributes=" + attributes +
+				'}';
+	}
+}

--- a/src/main/java/xdzk/curator/ContainerAware.java
+++ b/src/main/java/xdzk/curator/ContainerAware.java
@@ -1,0 +1,18 @@
+package xdzk.curator;
+
+import java.util.Iterator;
+
+/**
+ * Interface definition for an object with the ability to look up
+ * the set of containers available in the cluster.
+ *
+ * @author Patrick Peralta
+ */
+public interface ContainerAware {
+	/**
+	 * Return an {@link Iterator} over the available containers.
+	 *
+	 * @return iterator over the available containers
+	 */
+	Iterator<Container> getContainerIterator();
+}

--- a/src/main/java/xdzk/curator/ContainerServer.java
+++ b/src/main/java/xdzk/curator/ContainerServer.java
@@ -64,18 +64,19 @@ public class ContainerServer extends AbstractServer {
 			deployments = new PathChildrenCache(client, Paths.DEPLOYMENTS + "/" + this.getId(), false);
 			deployments.getListenable().addListener(deploymentListener);
 
-			Map<String, String> attributes = new HashMap<>();
 			String mxBeanName = ManagementFactory.getRuntimeMXBean().getName();
 			String tokens[] = mxBeanName.split("@");
-			attributes.put("pid", tokens[0]);
-			attributes.put("host", tokens[1]);
+			StringBuilder builder = new StringBuilder()
+					.append("pid=").append(tokens[0])
+					.append(System.lineSeparator())
+					.append("host=").append(tokens[1]);
 
 			client.create().withMode(CreateMode.EPHEMERAL).forPath(
-					Paths.CONTAINERS + "/" + this.getId(), attributes.toString().getBytes());
+					Paths.CONTAINERS + "/" + this.getId(), builder.toString().getBytes("UTF-8"));
 
 			deployments.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
 
-			LOG.info("Started container {} with attributes: {} ", this.getId(), attributes);
+			LOG.info("Started container {} with attributes: {} ", this.getId(), builder);
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);

--- a/src/main/java/xdzk/curator/StreamListener.java
+++ b/src/main/java/xdzk/curator/StreamListener.java
@@ -111,7 +111,7 @@ class StreamListener implements PathChildrenCacheListener {
 		LOG.info("Deploying module '{}' to container: {}", module, container);
 
 		try {
-			// todo: we need to specify whether container will contain the leading slash
+		// todo: we need to specify whether container will contain the leading slash
 //		client.create().creatingParentsIfNeeded().forPath(Paths.DEPLOYMENTS + '/' + container + '/' + module);
 			client.create().creatingParentsIfNeeded().forPath(Paths.DEPLOYMENTS + container + '/' + module);
 		}


### PR DESCRIPTION
Added some simple Container domain classes and supporting
interfaces. The ContainerAware interface provides access to
an iterator over all Containers in the cluster. ChildPathIterator
is a generic iterator over children nodes in a Curator/ZooKeeper
path.
