### PR TITLE
Introduced Module and Stream domain objects (do not merge)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	compile group : 'org.slf4j', name : 'slf4j-api', version: '1.7,6'
 	compile group : 'org.slf4j', name : 'slf4j-log4j12', version: '1.7.6'
 	compile group : 'log4j', name : 'log4j', version: '1.2.17'
+	compile group : 'com.fasterxml.jackson.core', name : 'jackson-databind', version: '2.2.2'
 	compile group : 'com.oracle.tools', name : 'oracle-tools-runtime', version: '1.2.1'
 	compile group : 'com.oracle.tools', name : 'oracle-tools-core', version: '1.2.1'
 	compile group : 'com.oracle.tools', name : 'oracle-tools-testing-support', version: '1.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,8 @@
 apply plugin: 'java'
+	compileJava {
+		sourceCompatibility = '1.6'
+		targetCompatibility = '1.6'
+	}
 apply plugin: 'eclipse'
 
 version = '1.0'

--- a/src/main/java/xdzk/cluster/ContainerMatcher.java
+++ b/src/main/java/xdzk/cluster/ContainerMatcher.java
@@ -16,7 +16,7 @@
 
 package xdzk.cluster;
 
-import java.util.Iterator;
+import xdzk.core.Module;
 
 
 /**
@@ -29,8 +29,9 @@ public interface ContainerMatcher {
 	/**
 	 * Matches the provided module against one of the candidate containers.
 	 *
-	 * @param moduleDeploymentRequest the module deployment request
-	 * @param candidates set of containers to which a module could be deployed
+	 *
+	 * @param module
+	 * @param containerRepository
 	 * @return the matched container, or <code>null</code> if no suitable match
 	 */
 	// TODO: The module name should be replaced with ModuleDeploymentRequest which will
@@ -38,6 +39,6 @@ public interface ContainerMatcher {
 	// metadata extracted from the stream deployment manifest, such as the number of instances.
 	// Also, the String return and collection element type should be Container instances
 	// where ultimately matching will take Container attributes and metrics into consideration.
-	Container match(String module, Iterator<Container> candidates);
+	Container match(Module module, ContainerRepository containerRepository);
 
 }

--- a/src/main/java/xdzk/cluster/RandomContainerMatcher.java
+++ b/src/main/java/xdzk/cluster/RandomContainerMatcher.java
@@ -34,7 +34,7 @@ public class RandomContainerMatcher implements ContainerMatcher {
 	 */
 	@Override
 	public Container match(String module, Iterator<Container> candidates) {
-		List<Container> containers = new ArrayList<>();
+		List<Container> containers = new ArrayList<Container>();
 		while (candidates.hasNext()) {
 			containers.add(candidates.next());
 		}

--- a/src/main/java/xdzk/cluster/RandomContainerMatcher.java
+++ b/src/main/java/xdzk/cluster/RandomContainerMatcher.java
@@ -16,6 +16,8 @@
 
 package xdzk.cluster;
 
+import xdzk.core.Module;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -31,12 +33,16 @@ public class RandomContainerMatcher implements ContainerMatcher {
 
 	/**
 	 * Randomly selects one of the candidate containers.
+	 *
+	 * @param module
+	 * @param containerRepository
 	 */
 	@Override
-	public Container match(String module, Iterator<Container> candidates) {
+	public Container match(Module module, ContainerRepository containerRepository) {
 		List<Container> containers = new ArrayList<Container>();
-		while (candidates.hasNext()) {
-			containers.add(candidates.next());
+		Iterator<Container> iterator = containerRepository.getContainerIterator();
+		while (iterator.hasNext()) {
+			containers.add(iterator.next());
 		}
 		return containers.isEmpty() ? null : containers.get(RANDOM.nextInt(containers.size()));
 	}

--- a/src/main/java/xdzk/core/MapBytesUtility.java
+++ b/src/main/java/xdzk/core/MapBytesUtility.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdzk.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Utility to convert {@link Map string key/value pairs} to/from
+ * byte arrays containing JSON strings. By default the JSON library
+ * encodes to UTF-8.
+ *
+ * @author Patrick Peralta
+ */
+public class MapBytesUtility {
+	/**
+	 * Serializer from map to JSON string in a byte array.
+	 */
+	private final ObjectWriter writer;
+
+	/**
+	 * Deserializer from JSON string in a byte array to a map.
+	 */
+	private final ObjectReader reader;
+
+	/**
+	 * Construct a MapBytesUtility.
+	 */
+	public MapBytesUtility() {
+		ObjectMapper mapper = new ObjectMapper();
+		writer = mapper.writer();
+		reader = mapper.reader(Map.class);
+	}
+
+	/**
+	 * Convert a map of string key/value pairs to a JSON string
+	 * in a byte array.
+	 *
+	 * @param map map to convert
+	 *
+	 * @return byte array
+	 */
+	public byte[] toByteArray(Map<String, String> map) {
+		try {
+			return writer.writeValueAsBytes(map);
+		}
+		catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Convert a byte array containing a JSON string to a map of key/value pairs.
+	 *
+	 * @param bytes byte array containing the key/value pair strings
+	 *
+	 * @return a new map instance containing the key/value pairs
+	 */
+	public Map<String, String> toMap(byte[] bytes) {
+		if (bytes == null) {
+			return Collections.emptyMap();
+		}
+		try {
+			return reader.readValue(bytes);
+		}
+		catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/xdzk/core/Module.java
+++ b/src/main/java/xdzk/core/Module.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdzk.core;
+
+/**
+ * Domain object for an XD module.
+ *
+ * @author Patrick Peralta
+ */
+public class Module {
+	/**
+	 * Type of module.
+	 */
+	public enum Type {
+		/**
+		 * Source module type. Indicates that this module will
+		 * be a data source (and thus the first module indicated
+		 * in a stream definition).
+		 */
+		SOURCE,
+
+		/**
+		 * Sink module type. Indicates that this module will
+		 * be a data sink (and thus the last module indicated
+		 * in a stream definition).
+		 */
+		SINK,
+
+		/**
+		 * Processor module type. Indicates that this module
+		 * processes data as it moves from a {@link #SOURCE}
+		 * to a {@link #SINK} module.
+		 */
+		PROCESSOR;
+
+		/**
+		 * {@inheritDoc}
+		 * <p/>
+		 * Returns the type in lower case. This is typically
+		 * used for module type naming in a repository.
+		 */
+		public String toString() {
+			return name().toLowerCase();
+		}
+	}
+
+	/**
+	 * Module type.
+	 */
+	private final Type type;
+
+	/**
+	 * Module name.
+	 */
+	private final String name;
+
+	/**
+	 * URL for loading this module.
+	 */
+	private final String url;
+
+	/**
+	 * Construct a Module.
+	 *
+	 * @param name  name of module
+	 * @param type  module type
+	 * @param url   URL where this module can be loaded
+	 */
+	public Module(String name, Type type, String url) {
+		this.name = name;
+		this.type = type;
+		this.url = url;
+	}
+
+	/**
+	 * Return the module type.
+	 *
+	 * @return module type
+	 */
+	public Type getType() {
+		return type;
+	}
+
+	/**
+	 * Return the module name.
+	 *
+	 * @return module name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Return the URL where this module can be loaded.
+	 *
+	 * @return URL where this module can be loaded
+	 */
+	public String getUrl() {
+		return url;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		return "Module{" +
+				"type=" + type +
+				", name='" + name + '\'' +
+				", url='" + url + '\'' +
+				'}';
+	}
+}

--- a/src/main/java/xdzk/core/ModuleRepository.java
+++ b/src/main/java/xdzk/core/ModuleRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdzk.core;
+
+/**
+ * Interface definition for a repository that contains {@link Module modules}.
+ *
+ * @author Patrick Peralta
+ */
+public interface ModuleRepository {
+	/**
+	 * Load the requested module.
+	 *
+	 * @param name  module name
+	 * @param type  module type
+	 *
+	 * @return the requested module
+	 */
+	Module loadModule(String name, Module.Type type);
+}

--- a/src/main/java/xdzk/core/Stream.java
+++ b/src/main/java/xdzk/core/Stream.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdzk.core;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * Domain model for an XD Stream. A stream consists of a set of modules
+ * used to process the flow of data.
+ *
+ * @author Patrick Peralta
+ */
+public class Stream {
+	/**
+	 * Name of stream.
+	 */
+	private final String name;
+
+	/**
+	 * Source module for this stream. This module is responsible for
+	 * obtaining data for this stream.
+	 */
+	private final Module source;
+
+	/**
+	 * Ordered list of processor modules. The data obtained by
+	 * the sink module will be fed to these processors in the order
+	 * indicated by this list.
+	 */
+	private final List<Module> processors;
+
+	/**
+	 * Sink module for this stream. This is the ultimate destination
+	 * for the stream data.
+	 */
+	private final Module sink;
+
+	/**
+	 * Properties for this stream.
+	 */
+	private final Map<String, String> properties;
+
+	/**
+	 * Construct a Stream.
+	 *
+	 * @param name        stream name
+	 * @param source      source module
+	 * @param processors  processor modules
+	 * @param sink        sink module
+	 * @param properties  stream properties
+	 */
+	private Stream(String name, Module source, List<Module> processors,
+				Module sink, Map<String, String> properties) {
+		this.name = name;
+		this.source = source;
+		this.processors = new LinkedList<Module>(processors);
+		this.sink = sink;
+		this.properties = properties;
+	}
+
+	/**
+	 * Return the name of this stream.
+	 *
+	 * @return stream name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Return the source module for this stream.
+	 *
+	 * @return source module
+	 */
+	public Module getSource() {
+		return source;
+	}
+
+	/**
+	 * Return the ordered list of processors for this stream.
+	 *
+	 * @return list of processors
+	 */
+	public List<Module> getProcessors() {
+		return Collections.unmodifiableList(processors);
+	}
+
+	/**
+	 * Return the sink for this stream.
+	 *
+	 * @return sink module
+	 */
+	public Module getSink() {
+		return sink;
+	}
+
+	/**
+	 * Return an iterator that indicates the order of module deployments
+	 * for this stream. The modules are returned in reverse order; i.e.
+	 * the sink is returned first followed by the processors in reverse
+	 * order followed by the source.
+	 *
+	 * @return iterator that iterates over the modules in deployment order
+	 */
+	public Iterator<Module> getDeploymentOrderIterator() {
+		return new DeploymentOrderIterator();
+	}
+
+	/**
+	 * Return the properties for this stream.
+	 *
+	 * @return stream properties
+	 */
+	public Map<String, String> getProperties() {
+		return properties;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		return "Stream{" +
+				"name='" + name + '\'' +
+				", source=" + source +
+				", processors=" + processors +
+				", sink=" + sink +
+				", properties=" + properties +
+				'}';
+	}
+
+	/**
+	 * Enumeration indicating the state of {@link DeploymentOrderIterator}.
+	 */
+	enum IteratorState {
+		/**
+		 * Indicates the iterator has not been used yet.
+		 */
+		INITIAL,
+
+		/**
+		 * Indicates that the first item in the iterator
+		 * has been returned (the sink module), thus causing the activation
+		 * of the processor module iterator.
+		 */
+		PROC_ITERATOR_ACTIVE,
+
+		/**
+		 * Indicates that the last item (the source module)
+		 * has been iterated over. Any subsequent iteration
+		 * will result in {@link java.util.NoSuchElementException}
+		 */
+		LAST_ITERATED
+	}
+
+	/**
+	 * Iterator that returns the modules in the order in which
+	 * they should be deployed. The sink module is returned
+	 * first, followed by processor modules in reverse order,
+	 * followed by the source module.
+	 */
+	class DeploymentOrderIterator implements Iterator<Module> {
+		/**
+		 * Iterator state.
+		 */
+		private IteratorState state;
+
+		/**
+		 * Iterator over the processor modules.
+		 */
+		private final Iterator<Module> processorIterator;
+
+		/**
+		 * Construct a DeploymentOrderIterator.
+		 */
+		@SuppressWarnings("unchecked")
+		DeploymentOrderIterator() {
+			assert processors instanceof Deque;
+			processorIterator = ((Deque) processors).descendingIterator();
+			state = IteratorState.INITIAL;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public boolean hasNext() {
+			return state != IteratorState.LAST_ITERATED;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public Module next() {
+			switch(state) {
+				case INITIAL:
+					state = IteratorState.PROC_ITERATOR_ACTIVE;
+					return sink;
+				case PROC_ITERATOR_ACTIVE:
+					if (processorIterator.hasNext()) {
+						return processorIterator.next();
+					}
+					else {
+						state = IteratorState.LAST_ITERATED;
+						return source;
+					}
+				case LAST_ITERATED:
+					throw new NoSuchElementException();
+				default:
+					throw new IllegalStateException();
+			}
+		}
+
+		/**
+		 * {@inheritDoc}
+		 * <p/>
+		 * This implementation throws {@link java.lang.UnsupportedOperationException}.
+		 */
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	/**
+	 * Builder object for {@link Stream} that supports fluent style configuration.
+	 */
+	public static class Builder {
+		/**
+		 * Stream name.
+		 */
+		private String name;
+
+		/**
+		 * Source module.
+		 */
+		private Module source;
+
+		/**
+		 * List of processor modules.
+		 */
+		private List<Module> processors = new ArrayList<Module>();
+
+		/**
+		 * Sink module.
+		 */
+		private Module sink;
+
+		/**
+		 * Stream properties
+		 */
+		private Map<String, String> properties;
+
+		/**
+		 * Return the stream name.
+		 *
+		 * @return stream name
+		 */
+		public String getName() {
+			return name;
+		}
+
+		/**
+		 * Set the stream name.
+		 *
+		 * @param name stream name
+		 *
+		 * @return this builder
+		 */
+		public Builder setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		/**
+		 * Add a module to this stream builder. Processor
+		 * modules will be added to the stream in the order
+		 * they are added to this builder.
+		 *
+		 * @param module module to add
+		 *
+		 * @return this builder
+		 */
+		public Builder addModule(Module module) {
+			switch (module.getType()) {
+				case SOURCE:
+					source = module;
+					break;
+				case PROCESSOR:
+					processors.add(module);
+				case SINK:
+					sink = module;
+			}
+
+			return this;
+		}
+
+		/**
+		 * Return the properties for the stream.
+		 *
+		 * @return stream properties
+		 */
+		public Map<String, String> getProperties() {
+			return properties;
+		}
+
+		/**
+		 * Set the properties for the stream.
+		 *
+		 * @param properties stream properties
+		 *
+		 * @return this builder
+		 */
+		public Builder setProperties(Map<String, String> properties) {
+			this.properties = properties;
+			return this;
+		}
+
+		/**
+		 * Create a new instance of {@link Stream}.
+		 *
+		 * @return new Stream instance
+		 */
+		public Stream build() {
+			return new Stream(name, source, processors, sink, properties);
+		}
+	}
+
+}

--- a/src/main/java/xdzk/core/StreamFactory.java
+++ b/src/main/java/xdzk/core/StreamFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdzk.core;
+
+import java.util.Map;
+
+/**
+ * @author Patrick Peralta
+ */
+public class StreamFactory {
+	private final ModuleRepository moduleRepository;
+
+	public StreamFactory(ModuleRepository moduleRepository) {
+		this.moduleRepository = moduleRepository;
+	}
+
+	public Stream createStream(String name, String dsl, Map<String, String> properties) {
+		String[] modules = dsl.split("\\|");
+
+		Stream.Builder builder = new Stream.Builder();
+		builder.setName(name);
+		builder.setProperties(properties);
+
+		for (int i = 0; i < modules.length; i++) {
+			Module module = moduleRepository.loadModule(modules[i].trim(),
+					i == 0 ? Module.Type.SOURCE
+							: i == modules.length - 1 ? Module.Type.SINK
+							: Module.Type.PROCESSOR);
+
+			builder.addModule(module);
+		}
+
+		return builder.build();
+	}
+
+}

--- a/src/main/java/xdzk/core/StubModuleRepository.java
+++ b/src/main/java/xdzk/core/StubModuleRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdzk.core;
+
+/**
+ * Stub implementation of {@link xdzk.core.ModuleRepository}
+ * used for testing.
+ *
+ * @author Patrick Peralta
+ */
+public class StubModuleRepository implements ModuleRepository {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Module loadModule(String name, Module.Type type) {
+		return new Module(name, type, "file:///modules/" + name);
+	}
+}

--- a/src/main/java/xdzk/curator/Paths.java
+++ b/src/main/java/xdzk/curator/Paths.java
@@ -31,7 +31,7 @@ public class Paths {
 	/**
 	 * Map of paths to {@link org.apache.curator.utils.EnsurePath} instances.
 	 */
-	private static final ConcurrentMap<String, EnsurePath> ensurePaths = new ConcurrentHashMap<>();
+	private static final ConcurrentMap<String, EnsurePath> ensurePaths = new ConcurrentHashMap<String, EnsurePath>();
 
 	/**
 	 * Namespace path (i.e. the top node in the hierarchy)

--- a/src/main/java/xdzk/curator/Paths.java
+++ b/src/main/java/xdzk/curator/Paths.java
@@ -74,6 +74,39 @@ public class Paths {
 	}
 
 	/**
+	 * Return a string with the provided path elements separated
+	 * by a slash {@code /}.
+	 *
+	 * @param elements path elements
+	 *
+	 * @return the full path
+	 */
+	public static String createPath(String... elements) {
+		StringBuilder builder = new StringBuilder();
+		for (int i = 0; i < elements.length; i++) {
+			builder.append(elements[i]);
+			if (i + 1 < elements.length) {
+				builder.append('/');
+			}
+		}
+
+		return builder.toString();
+	}
+
+	/**
+	 * Return a string with the provided path elements separated
+	 * by a slash {@code /}. The {@link #XD_NAMESPACE} is included
+	 * as a prefix.
+	 *
+	 * @param elements path elements
+	 *
+	 * @return the full path
+	 */
+	public static String createPathWithNamespace(String... elements) {
+		return '/' + XD_NAMESPACE + '/' + createPath(elements);
+	}
+
+	/**
 	 * Ensure the existence of the given path.
 	 *
 	 * @param client  curator client

--- a/src/main/java/xdzk/server/AdminServer.java
+++ b/src/main/java/xdzk/server/AdminServer.java
@@ -142,7 +142,7 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 	public Set<String> getContainerPaths() {
 		// todo: instead of returning a set here, perhaps
 		// we can return Iterator<String>
-		Set<String> containerSet = new HashSet<>();
+		Set<String> containerSet = new HashSet<String>();
 		for (ChildData child : containers.getCurrentData()) {
 			containerSet.add(child.getPath());
 		}
@@ -157,7 +157,7 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 	public Set<String> getStreamPaths() {
 		// todo: instead of returning a set here, perhaps
 		// we can return Iterator<String>
-		Set<String> streamSet = new HashSet<>();
+		Set<String> streamSet = new HashSet<String>();
 		for (ChildData child : streams.getCurrentData()) {
 			streamSet.add(child.getPath());
 		}
@@ -276,7 +276,7 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 			// iterator returned by getContainerIterator. While elegant,
 			// this isn't exactly efficient. TODO - revisit
 			try {
-				Map<String, String> attributes = new HashMap<>();
+				Map<String, String> attributes = new HashMap<String, String>();
 				byte[] data = source.getData();
 
 				if (data != null) {

--- a/src/test/java/demo/StreamWriter.java
+++ b/src/test/java/demo/StreamWriter.java
@@ -24,7 +24,10 @@ import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import xdzk.core.MapBytesUtility;
 import xdzk.curator.Paths;
+
+import java.util.Collections;
 
 /**
  * @author Mark Fisher
@@ -44,7 +47,10 @@ public class StreamWriter {
 
 	private static void createStream(ZooKeeper client, String name, String definition) {
 		try {
-			client.create(Paths.STREAMS + '/' + name, definition.getBytes("UTF-8"),
+			MapBytesUtility utility = new MapBytesUtility();
+
+			client.create(Paths.createPathWithNamespace(Paths.STREAMS, name),
+					utility.toByteArray(Collections.singletonMap("definition", definition)),
 					ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 		}
 		catch (InterruptedException e) {

--- a/src/test/java/xdzk/admin/AdminContainerObserverTest.java
+++ b/src/test/java/xdzk/admin/AdminContainerObserverTest.java
@@ -95,7 +95,7 @@ public class AdminContainerObserverTest {
 			}
 		}
 		NativeJavaApplicationBuilder<SimpleJavaApplication, SimpleJavaApplicationSchema> builder =
-				new NativeJavaApplicationBuilder<>();
+				new NativeJavaApplicationBuilder<SimpleJavaApplication, SimpleJavaApplicationSchema>();
 		return builder.realize(schema, clz.getName(), new SystemApplicationConsole());
 	}
 
@@ -111,7 +111,7 @@ public class AdminContainerObserverTest {
 	public Set<String> getCurrentContainers(JavaApplication<SimpleJavaApplication> adminServer) throws Exception {
 		final Set<String> containers = Collections.synchronizedSet(new HashSet<String>());
 		final CountDownLatch latch = new CountDownLatch(1);
-		final AtomicReference<Exception> exception = new AtomicReference<>();
+		final AtomicReference<Exception> exception = new AtomicReference<Exception>();
 
 		adminServer.submit(new AdminServer.CurrentContainers(), new CompletionListener<Collection<String>>() {
 			@Override

--- a/src/test/java/xdzk/core/StreamTest.java
+++ b/src/test/java/xdzk/core/StreamTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdzk.core;
+
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Patrick Peralta
+ */
+public class StreamTest {
+	@Test
+	public void testSimpleStream() {
+		ModuleRepository moduleRepository = new StubModuleRepository();
+		StreamFactory streamFactory = new StreamFactory(moduleRepository);
+		Stream stream = streamFactory.createStream("ticktock", "time | log", null);
+
+		assertEquals("ticktock", stream.getName());
+		Iterator<Module> iterator = stream.getDeploymentOrderIterator();
+		assertTrue(iterator.hasNext());
+
+		String[] moduleNames = {"log", "time"};
+		for (String moduleName : moduleNames) {
+			Module module = iterator.next();
+			assertEquals(moduleName, module.getName());
+		}
+
+		assertFalse(iterator.hasNext());
+
+		try {
+			iterator.next();
+			fail("Expected NoSuchElementException");
+		}
+		catch (NoSuchElementException e) {
+			// expected
+		}
+	}
+
+	@Test
+	public void testProcessorStream() {
+		ModuleRepository moduleRepository = new StubModuleRepository();
+		StreamFactory streamFactory = new StreamFactory(moduleRepository);
+
+		Stream stream = streamFactory.createStream("fancy-http", "http | transform | filter | log", null);
+
+		assertEquals("fancy-http", stream.getName());
+		Iterator<Module> iterator = stream.getDeploymentOrderIterator();
+		assertTrue(iterator.hasNext());
+
+		String[] moduleNames = {"log", "filter", "transform", "http"};
+		for (String moduleName : moduleNames) {
+			Module module = iterator.next();
+			assertEquals(moduleName, module.getName());
+		}
+
+		assertFalse(iterator.hasNext());
+
+		try {
+			iterator.next();
+			fail("Expected NoSuchElementException");
+		}
+		catch (NoSuchElementException e) {
+			// expected
+		}
+	}
+
+}


### PR DESCRIPTION
This PR contains two commits - the first is simply enforcing 1.6 compatibility. I would instead concentrate on 051b11a as it contains the new `xdzk.core` package. The next step is to modify `StreamListener` to use these objects. 

Notice that these objects have the bare basics (and the lack of JavaDoc) - so I request that this branch not be merged at this time as I may rebase or amend the last commit. I wanted to get this out there so you could take a quick look if you have time.
