### PR TITLE
Admin server deployment enhancements

### DIFF
--- a/src/main/java/xdzk/cluster/Container.java
+++ b/src/main/java/xdzk/cluster/Container.java
@@ -16,6 +16,8 @@
 
 package xdzk.cluster;
 
+import org.springframework.util.Assert;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,6 +46,7 @@ public class Container {
 	 * @param attributes  container attributes
 	 */
 	public Container(String name, Map<String, String> attributes) {
+		Assert.hasText(name);
 		this.name = name;
 		this.attributes = Collections.unmodifiableMap(new HashMap<String, String>(attributes));
 	}
@@ -64,6 +67,22 @@ public class Container {
 	 */
 	public Map<String, String> getAttributes() {
 		return attributes;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean equals(Object o) {
+		return o instanceof Container && name.equals(((Container) o).getName());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int hashCode() {
+		return name.hashCode();
 	}
 
 	/**

--- a/src/main/java/xdzk/cluster/Container.java
+++ b/src/main/java/xdzk/cluster/Container.java
@@ -17,10 +17,13 @@
 package xdzk.cluster;
 
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Domain object for an XD container. This object is typically constructed
@@ -40,6 +43,11 @@ public class Container {
 	private final Map<String, String> attributes;
 
 	/**
+	 * Set of groups this container belongs to.
+	 */
+	private final Set<String> groups;
+
+	/**
 	 * Construct a Container object.
 	 *
 	 * @param name        container name
@@ -49,6 +57,15 @@ public class Container {
 		Assert.hasText(name);
 		this.name = name;
 		this.attributes = Collections.unmodifiableMap(new HashMap<String, String>(attributes));
+		String groupList = attributes.get("groups");
+		if (groupList == null) {
+			groups = Collections.emptySet();
+		}
+		else {
+			Set<String> set = new HashSet<String>();
+			Collections.addAll(set, StringUtils.tokenizeToStringArray(groupList, ","));
+			this.groups = Collections.unmodifiableSet(set);
+		}
 	}
 
 	/**
@@ -67,6 +84,15 @@ public class Container {
 	 */
 	public Map<String, String> getAttributes() {
 		return attributes;
+	}
+
+	/**
+	 * Return the set of groups this container belongs to.
+	 *
+	 * @return read-only set of groups this container belongs to
+	 */
+	public Set<String> getGroups() {
+		return groups;
 	}
 
 	/**

--- a/src/main/java/xdzk/cluster/ContainerMatcher.java
+++ b/src/main/java/xdzk/cluster/ContainerMatcher.java
@@ -16,7 +16,9 @@
 
 package xdzk.cluster;
 
-import xdzk.core.Module;
+import xdzk.core.ModuleDescriptor;
+
+import java.util.Collection;
 
 
 /**
@@ -30,15 +32,13 @@ public interface ContainerMatcher {
 	 * Matches the provided module against one of the candidate containers.
 	 *
 	 *
-	 * @param module
-	 * @param containerRepository
-	 * @return the matched container, or <code>null</code> if no suitable match
+	 * @param moduleDescriptor                the module to match against
+	 * @param containerRepository   the container repository that provides the
+	 *                              ability to look up containers
+	 *
+	 * @return a collection of matched containers; collection is empty if no
+	 *         suitable containers are found
 	 */
-	// TODO: The module name should be replaced with ModuleDeploymentRequest which will
-	// include the criteria for matching against container attributes as well as other
-	// metadata extracted from the stream deployment manifest, such as the number of instances.
-	// Also, the String return and collection element type should be Container instances
-	// where ultimately matching will take Container attributes and metrics into consideration.
-	Container match(Module module, ContainerRepository containerRepository);
+	Collection<Container> match(ModuleDescriptor moduleDescriptor, ContainerRepository containerRepository);
 
 }

--- a/src/main/java/xdzk/cluster/DeploymentManifestMatcher.java
+++ b/src/main/java/xdzk/cluster/DeploymentManifestMatcher.java
@@ -54,7 +54,6 @@ public class DeploymentManifestMatcher implements ContainerMatcher {
 	 */
 	@Override
 	public Collection<Container> match(ModuleDescriptor moduleDescriptor, ContainerRepository containerRepository) {
-		// todo: this method needs unit testing
 		LOG.debug("Matching containers for module {}", moduleDescriptor);
 
 		String group = moduleDescriptor.getGroup();
@@ -75,27 +74,26 @@ public class DeploymentManifestMatcher implements ContainerMatcher {
 		}
 
 		int count = moduleDescriptor.getCount();
-		if (count <= 0) {
-			// count of 0 means all members of the group;
-			// if no group specified it means all containers
+		int candidateCount = candidates.size();
+		if (count <= 0 || count >= candidateCount) {
+			// count of 0 means all members of the group
+			// (if no group specified it means all containers);
+			// count >= candidates means each of the
+			// containers should host a module
 			return candidates;
 		}
 		else if (count == 1) {
-			if (index + 1 > candidates.size()) {
+			if (index + 1 > candidateCount) {
 				index = 0;
 			}
 			return Collections.singleton(candidates.get(index++));
 		}
 		else {
 			// create a new list with the specific number
-			// of targeted containers
+			// of targeted containers;
 			List<Container> targets = new ArrayList<Container>();
-			// todo: this will create the exact number of module deployments
-			// regardless of the number of containers; this means some
-			// containers may get multiple deployments if the module
-			// specifies more deployments than containers
 			while (targets.size() < count) {
-				if (index + 1 > candidates.size()) {
+				if (index + 1 > candidateCount) {
 					index = 0;
 				}
 				targets.add(candidates.get(index++));

--- a/src/main/java/xdzk/core/ModuleDescriptor.java
+++ b/src/main/java/xdzk/core/ModuleDescriptor.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdzk.core;
+
+/**
+ * A descriptor for module deployment for a specific {@link Stream}.
+ * Many attributes of this class are derived from the stream deployment manifest.
+ *
+ * @author Patrick Peralta
+ */
+public class ModuleDescriptor {
+	/**
+	 * Module type.
+	 */
+	private final Module module;
+
+	/**
+	 * Name of stream using this module.
+	 */
+	private final String streamName;
+
+	/**
+	 * Order of processing for this module. Only applies to modules of type
+	 * {@link xdzk.core.Module.Type#PROCESSOR}.
+	 */
+	private final int index;
+
+	/**
+	 * Group of containers this module should be deployed to.
+	 */
+	private final String group;
+
+	/**
+	 * Number of container instances this module should be deployed to.
+	 */
+	private final int count;
+
+	/**
+	 * Construct a ModuleDescriptor.
+	 *
+	 * @param module      module type
+	 * @param streamName  name of stream using this module
+	 * @param index       order of processing for this module
+	 * @param group       container group this module should be deployed to
+	 * @param count       number of container instances this module should be deployed to
+	 */
+	public ModuleDescriptor(Module module, String streamName, int index, String group, int count) {
+		this.module = module;
+		this.streamName = streamName;
+		this.index = index;
+		this.group = group;
+		this.count = count;
+	}
+
+	/**
+	 * Return the module type.
+	 *
+	 * @return module type
+	 */
+	public Module getModule() {
+		return module;
+	}
+
+	/**
+	 * Return the name of the stream using this module.
+	 *
+	 * @return stream name
+	 */
+	public String getStreamName() {
+		return streamName;
+	}
+
+	/**
+	 * Return the order of processing for this module. Only applies to modules of type
+	 * {@link xdzk.core.Module.Type#PROCESSOR}.
+	 *
+	 * @return order of processing for this module
+	 */
+
+	public int getIndex() {
+		return index;
+	}
+
+	/**
+	 * Return the group of containers this module should be deployed to.
+	 *
+	 * @return container group name
+	 */
+	public String getGroup() {
+		return group;
+	}
+
+	/**
+	 * Return the number of container instances this module should be deployed to.
+	 *
+	 * @return number of container instances
+	 */
+	public int getCount() {
+		return count;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		return module.getType() + "/" + module.getName();
+	}
+}

--- a/src/main/java/xdzk/core/ModuleDescriptor.java
+++ b/src/main/java/xdzk/core/ModuleDescriptor.java
@@ -134,6 +134,6 @@ public class ModuleDescriptor {
 	 */
 	@Override
 	public String toString() {
-		return module.getType() + "/" + module.getName();
+		return String.format("%s: %s type=%s, group=%s", label, module.getName(), module.getType(), group);
 	}
 }

--- a/src/main/java/xdzk/core/ModuleDescriptor.java
+++ b/src/main/java/xdzk/core/ModuleDescriptor.java
@@ -24,7 +24,7 @@ package xdzk.core;
  */
 public class ModuleDescriptor {
 	/**
-	 * Module type.
+	 * The module.
 	 */
 	private final Module module;
 
@@ -58,8 +58,9 @@ public class ModuleDescriptor {
 	/**
 	 * Construct a ModuleDescriptor.
 	 *
-	 * @param module      module type
+	 * @param module      the module for this descriptor
 	 * @param streamName  name of stream using this module
+	 * @param label       label for this module as defined by its stream
 	 * @param index       order of processing for this module
 	 * @param group       container group this module should be deployed to
 	 * @param count       number of container instances this module should be deployed to
@@ -74,9 +75,9 @@ public class ModuleDescriptor {
 	}
 
 	/**
-	 * Return the module type.
+	 * Return the module for this descriptor.
 	 *
-	 * @return module type
+	 * @return the module
 	 */
 	public Module getModule() {
 		return module;
@@ -101,8 +102,9 @@ public class ModuleDescriptor {
 	}
 
 	/**
-	 * Return the order of processing for this module. Only applies to modules of type
-	 * {@link xdzk.core.Module.Type#PROCESSOR}.
+	 * Return the order of processing for this module. Module 0 indicates
+	 * this is a source module, 1 indicates that a source is sending
+	 * data to this module, etc.
 	 *
 	 * @return order of processing for this module
 	 */

--- a/src/main/java/xdzk/core/ModuleDescriptor.java
+++ b/src/main/java/xdzk/core/ModuleDescriptor.java
@@ -34,6 +34,12 @@ public class ModuleDescriptor {
 	private final String streamName;
 
 	/**
+	 * Label used to uniquely identify this module in the context
+	 * of the stream it belongs to.
+	 */
+	private final String label;
+
+	/**
 	 * Order of processing for this module. Only applies to modules of type
 	 * {@link xdzk.core.Module.Type#PROCESSOR}.
 	 */
@@ -58,9 +64,10 @@ public class ModuleDescriptor {
 	 * @param group       container group this module should be deployed to
 	 * @param count       number of container instances this module should be deployed to
 	 */
-	public ModuleDescriptor(Module module, String streamName, int index, String group, int count) {
+	public ModuleDescriptor(Module module, String streamName, String label, int index, String group, int count) {
 		this.module = module;
 		this.streamName = streamName;
+		this.label = label;
 		this.index = index;
 		this.group = group;
 		this.count = count;
@@ -82,6 +89,15 @@ public class ModuleDescriptor {
 	 */
 	public String getStreamName() {
 		return streamName;
+	}
+
+	/**
+	 * Return the label for this module as defined by its stream.
+	 *
+	 * @return label for this module
+	 */
+	public String getLabel() {
+		return label;
 	}
 
 	/**

--- a/src/main/java/xdzk/core/Stream.java
+++ b/src/main/java/xdzk/core/Stream.java
@@ -162,6 +162,41 @@ public class Stream {
 	}
 
 	/**
+	 * Return the module descriptor for the given module name and type.
+	 *
+	 * @param moduleName  module name
+	 * @param moduleType  module type
+	 *
+	 * @return module descriptor
+	 *
+	 * @throws IllegalArgumentException if the module name/type cannot be found
+	 */
+	public ModuleDescriptor getModuleDescriptor(String moduleName, String moduleType) {
+		Module.Type type = Module.Type.valueOf(moduleType.toUpperCase());
+		ModuleDescriptor moduleDescriptor = null;
+		switch (type) {
+			case SOURCE:
+				moduleDescriptor = getSource();
+				break;
+			case SINK:
+				moduleDescriptor = getSink();
+				break;
+			case PROCESSOR:
+				for (ModuleDescriptor processor : processors) {
+					if (processor.getModule().getName().equals(moduleName)) {
+						moduleDescriptor = processor;
+						break;
+					}
+				}
+		}
+		if (moduleDescriptor == null || !moduleName.equals(moduleDescriptor.getModule().getName())) {
+			throw new IllegalArgumentException(String.format("Module %s of type %s not found", moduleName, moduleType));
+		}
+
+		return moduleDescriptor;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	@Override

--- a/src/main/java/xdzk/core/StreamFactory.java
+++ b/src/main/java/xdzk/core/StreamFactory.java
@@ -32,6 +32,7 @@ public class StreamFactory {
 
 	public Stream createStream(String name, Map<String, String> properties) {
 		Assert.hasText(name, "Stream name is required");
+		Assert.notNull(properties, "Stream properties are required");
 
 		String definition = properties.get("definition");
 		Assert.hasText(definition, "Stream deployment manifest requires a 'definition' property");

--- a/src/main/java/xdzk/core/StreamFactory.java
+++ b/src/main/java/xdzk/core/StreamFactory.java
@@ -30,11 +30,12 @@ public class StreamFactory {
 		this.moduleRepository = moduleRepository;
 	}
 
-	public Stream createStream(String name, String dsl, Map<String, String> properties) {
-		String[] modules = dsl.split("\\|");
+	public Stream createStream(String name, Map<String, String> properties) {
+		Assert.hasText(name);
+
+		String[] modules = properties.get("definition").split("\\|");
 
 		Stream.Builder builder = new Stream.Builder();
-		Assert.hasText(name);
 		builder.setName(name);
 		if (properties != null) {
 			builder.setProperties(properties);

--- a/src/main/java/xdzk/core/StreamFactory.java
+++ b/src/main/java/xdzk/core/StreamFactory.java
@@ -16,6 +16,8 @@
 
 package xdzk.core;
 
+import org.springframework.util.Assert;
+
 import java.util.Map;
 
 /**
@@ -32,8 +34,11 @@ public class StreamFactory {
 		String[] modules = dsl.split("\\|");
 
 		Stream.Builder builder = new Stream.Builder();
+		Assert.hasText(name);
 		builder.setName(name);
-		builder.setProperties(properties);
+		if (properties != null) {
+			builder.setProperties(properties);
+		}
 
 		for (int i = 0; i < modules.length; i++) {
 			Module module = moduleRepository.loadModule(modules[i].trim(),

--- a/src/main/java/xdzk/curator/ChildPathIterator.java
+++ b/src/main/java/xdzk/curator/ChildPathIterator.java
@@ -16,12 +16,15 @@
 
 package xdzk.curator;
 
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.Assert;
 
 /**
  * Iterator over {@link ChildData} instances that are managed by {@link PathChildrenCache}.
@@ -49,8 +52,12 @@ public class ChildPathIterator<T> implements Iterator<T> {
 	 * @param cache      source for children nodes
 	 */
 	public ChildPathIterator(Converter<ChildData, T> converter, PathChildrenCache cache) {
+		Assert.notNull(converter);
+		Assert.notNull(cache);
+
 		this.converter = converter;
-		this.iterator = cache.getCurrentData().iterator();
+		List<ChildData> list = cache.getCurrentData();
+		this.iterator = list == null ? Collections.<ChildData>emptyIterator() : list.iterator();
 	}
 
 	/**

--- a/src/main/java/xdzk/curator/Paths.java
+++ b/src/main/java/xdzk/curator/Paths.java
@@ -69,8 +69,8 @@ public class Paths {
 	 * @return string with path stripped
 	 */
 	public static String stripPath(String path) {
-		// todo: error handling
-		return path.substring(path.lastIndexOf('/') + 1);
+		int i = path.lastIndexOf('/');
+		return i > -1 ? path.substring(i + 1) : path;
 	}
 
 	/**
@@ -81,7 +81,7 @@ public class Paths {
 	 *
 	 * @return the full path
 	 */
-	public static String createPath(String... elements) {
+	public static String build(String... elements) {
 		StringBuilder builder = new StringBuilder();
 		for (int i = 0; i < elements.length; i++) {
 			builder.append(elements[i]);
@@ -102,8 +102,8 @@ public class Paths {
 	 *
 	 * @return the full path
 	 */
-	public static String createPathWithNamespace(String... elements) {
-		return '/' + XD_NAMESPACE + '/' + createPath(elements);
+	public static String buildWithNamespace(String... elements) {
+		return '/' + XD_NAMESPACE + '/' + build(elements);
 	}
 
 	/**

--- a/src/main/java/xdzk/server/AbstractServer.java
+++ b/src/main/java/xdzk/server/AbstractServer.java
@@ -28,6 +28,7 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
+import org.springframework.util.Assert;
 import xdzk.curator.Paths;
 
 /**
@@ -71,12 +72,14 @@ public class AbstractServer implements Runnable, SmartLifecycle {
 	 * @param hostPort host name and port number in the format {@code host:port}.
 	 */
 	AbstractServer(String hostPort) {
+		Assert.hasText(hostPort, "host:port for ZooKeeper required");
 		id = UUID.randomUUID().toString();
 		client = CuratorFrameworkFactory.builder()
 				.namespace(Paths.XD_NAMESPACE)
 				.retryPolicy(retryPolicy)
 				.connectString(hostPort).build();
 		client.getConnectionStateListenable().addListener(connectionListener);
+		LOG.info("ZooKeeper host: {}", hostPort);
 	}
 
 	/**

--- a/src/main/java/xdzk/server/AdminApplication.java
+++ b/src/main/java/xdzk/server/AdminApplication.java
@@ -118,7 +118,7 @@ public class AdminApplication {
 			// an IllegalStateException is thrown; therefore
 			// don't hold the application context until the first refresh
 			if (applicationContext == null) {
-				applicationContext = (ApplicationContext) event.getSource();
+				applicationContext = event.getApplicationContext();
 			}
 		}
 	}

--- a/src/main/java/xdzk/server/AdminApplication.java
+++ b/src/main/java/xdzk/server/AdminApplication.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -109,16 +108,16 @@ public class AdminApplication {
 	/**
 	 * Application lifecycle listener.
 	 */
-	public static class AdminApplicationListener implements ApplicationListener {
+	public static class AdminApplicationListener implements ApplicationListener<ContextRefreshedEvent> {
 
 		@Override
-		public void onApplicationEvent(ApplicationEvent event) {
+		public void onApplicationEvent(ContextRefreshedEvent event) {
 			LOG.trace("Application event: {}", event);
 
-			if (event instanceof ContextRefreshedEvent) {
-				// if the application context is used before refresh
-				// an IllegalStateException is thrown; therefore
-				// don't hold the application context until the first refresh
+			// if the application context is used before refresh
+			// an IllegalStateException is thrown; therefore
+			// don't hold the application context until the first refresh
+			if (applicationContext == null) {
 				applicationContext = (ApplicationContext) event.getSource();
 			}
 		}

--- a/src/main/java/xdzk/server/AdminServer.java
+++ b/src/main/java/xdzk/server/AdminServer.java
@@ -300,6 +300,7 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 					String streamName = parts[0];
 					String moduleType = parts[1];
 					String moduleName = parts[2];
+					String moduleLabel = parts[3];
 
 					Stream stream = streamMap.get(streamName);
 					if (stream == null) {
@@ -327,7 +328,7 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 
 							client.create().creatingParentsIfNeeded().forPath(
 									Paths.createPath(Paths.DEPLOYMENTS, targetName,
-											String.format("%s.%s.%s", streamName, moduleType, moduleName)));
+											String.format("%s.%s.%s.%s", streamName, moduleType, moduleName, moduleLabel)));
 
 							// todo: not going to bother verifying the redeployment for now
 						}

--- a/src/main/java/xdzk/server/AdminServer.java
+++ b/src/main/java/xdzk/server/AdminServer.java
@@ -35,9 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.core.convert.converter.Converter;
 
-import xdzk.cluster.ContainerMatcher;
 import xdzk.cluster.ContainerRepository;
-import xdzk.cluster.RandomContainerMatcher;
 import xdzk.cluster.Container;
 import xdzk.core.ModuleRepository;
 import xdzk.curator.Paths;
@@ -99,12 +97,6 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 	 * Listener that is invoked when this admin server is elected leader.
 	 */
 	private final LeaderSelectorListener leaderListener = new LeaderListener();
-
-	/**
-	 * Container matcher used to match containers to module deployments.
-	 */
-	// TODO: make this pluggable
-	private final ContainerMatcher containerMatcher = new RandomContainerMatcher();
 
 	/**
 	 * Converter from {@link ChildData} types to {@link xdzk.cluster.Container}.
@@ -173,16 +165,6 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 	@Override
 	public Iterator<Container> getContainerIterator() {
 		return new ChildPathIterator<Container>(containerConverter, containers);
-	}
-
-	/**
-	 * Return the configured {@link xdzk.cluster.ContainerMatcher}. This matcher
-	 * is used to match a container to a module deployment request.
-	 *
-	 * @return container matcher for this admin server
-	 */
-	public ContainerMatcher getContainerMatcher() {
-		return containerMatcher;
 	}
 
 	/**
@@ -320,7 +302,7 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 		public void takeLeadership(CuratorFramework client) throws Exception {
 			LOG.info("Leader Admin {} is watching for stream deployment requests.", getId());
 			PathChildrenCacheListener streamListener =
-					new StreamListener(AdminServer.this, containerMatcher, moduleRepository);
+					new StreamListener(AdminServer.this, moduleRepository);
 
 			try {
 				streams = new PathChildrenCache(client, Paths.STREAMS, true);

--- a/src/main/java/xdzk/server/AdminServer.java
+++ b/src/main/java/xdzk/server/AdminServer.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.StringUtils;
 
 import xdzk.cluster.ContainerRepository;
 import xdzk.cluster.Container;
@@ -309,10 +310,7 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 						streamMap.put(streamName, stream);
 					}
 					ModuleDescriptor moduleDescriptor = stream.getModuleDescriptor(moduleName, moduleType);
-					if ("all".equals(moduleDescriptor.getGroup())) {
-						LOG.info("Module {} is deployed on every container, it does not need to be redeployed", moduleName);
-					}
-					else {
+					if (StringUtils.isEmpty(moduleDescriptor.getGroup())) {
 						// for now assume that just one redeployment is needed
 
 						// todo: refactor duplicate code from StreamListener
@@ -336,6 +334,10 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 							// uh oh
 							LOG.warn("No containers available for redeployment of {} for stream {}", moduleName, streamName);
 						}
+					}
+					else {
+						LOG.info("Module {} is targeted to containers belonging to group '{}'; it does not need to be redeployed",
+								moduleName, moduleDescriptor.getGroup());
 					}
 				}
 			}

--- a/src/main/java/xdzk/server/AdminServer.java
+++ b/src/main/java/xdzk/server/AdminServer.java
@@ -38,7 +38,6 @@ import xdzk.cluster.ContainerRepository;
 import xdzk.cluster.Container;
 import xdzk.core.ModuleRepository;
 import xdzk.core.MapBytesUtility;
-import xdzk.core.StreamFactory;
 import xdzk.curator.Paths;
 import xdzk.curator.ChildPathIterator;
 
@@ -176,7 +175,7 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 			Paths.ensurePath(client, Paths.CONTAINERS);
 			Paths.ensurePath(client, Paths.STREAMS);
 
-			leaderSelector = new LeaderSelector(client, Paths.createPathWithNamespace(Paths.ADMIN), leaderListener);
+			leaderSelector = new LeaderSelector(client, Paths.buildWithNamespace(Paths.ADMIN), leaderListener);
 			leaderSelector.setId(getId());
 			leaderSelector.start();
 		}
@@ -225,7 +224,7 @@ public class AdminServer extends AbstractServer implements ContainerRepository {
 			throw new IllegalArgumentException("definition must not be null");
 		}
 		try {
-			getClient().create().forPath(Paths.createPath(Paths.STREAMS, name),
+			getClient().create().forPath(Paths.build(Paths.STREAMS, name),
 					mapBytesUtility.toByteArray(Collections.singletonMap("definition", definition)));
 		}
 		catch (Exception e) {

--- a/src/main/java/xdzk/server/ContainerApplication.java
+++ b/src/main/java/xdzk/server/ContainerApplication.java
@@ -65,7 +65,8 @@ public class ContainerApplication {
 	 */
 	@Bean
 	public ContainerServer containerServer() {
-		return new ContainerServer(env.getProperty("zk", "localhost:2181"), mapBytesUtility(), moduleRepository());
+		return new ContainerServer(env.getProperty("zk", "localhost:2181"), env.getProperty("groups"),
+				mapBytesUtility(), moduleRepository());
 	}
 
 	/**

--- a/src/main/java/xdzk/server/ContainerListener.java
+++ b/src/main/java/xdzk/server/ContainerListener.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdzk.server;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.StringUtils;
+import xdzk.cluster.Container;
+import xdzk.cluster.ContainerRepository;
+import xdzk.core.MapBytesUtility;
+import xdzk.core.ModuleDescriptor;
+import xdzk.core.ModuleRepository;
+import xdzk.core.Stream;
+import xdzk.core.StreamFactory;
+import xdzk.curator.ChildPathIterator;
+import xdzk.curator.Paths;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Listener implementation that is invoked when containers are added/removed/modified.
+ *
+ * @author Patrick Peralta
+ */
+public class ContainerListener implements PathChildrenCacheListener {
+	/**
+	 * Logger.
+	 */
+	private final Logger LOG = LoggerFactory.getLogger(ContainerListener.class);
+
+	/**
+	 * Provides access to the current container list.
+	 */
+	private final ContainerRepository containerRepository;
+
+	/**
+	 * Utility to convert maps to byte arrays.
+	 */
+	private final MapBytesUtility mapBytesUtility = new MapBytesUtility();
+
+	/**
+	 * Stream factory.
+	 */
+	private final StreamFactory streamFactory;
+
+	/**
+	 * {@link Converter} from {@link ChildData} to {@link Stream}.
+	 */
+	private final StreamConverter streamConverter = new StreamConverter();
+
+	/**
+	 * Cache of children under the streams path.
+	 */
+	private final PathChildrenCache streams;
+
+
+	/**
+	 * Construct a ContainerListener.
+	 *
+	 * @param containerRepository repository to obtain container data
+	 * @param moduleRepository    repository to obtain module data
+	 * @param streams             cache of children under the streams path
+	 */
+	public ContainerListener(ContainerRepository containerRepository, ModuleRepository moduleRepository,
+			PathChildrenCache streams) {
+		this.containerRepository = containerRepository;
+		this.streamFactory = new StreamFactory(moduleRepository);
+		this.streams = streams;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
+		switch (event.getType()) {
+			case CHILD_ADDED:
+				onChildAdded(client, event.getData());
+				break;
+			case CHILD_UPDATED:
+				LOG.info("Container updated: {}", Paths.stripPath(event.getData().getPath()));
+				break;
+			case CHILD_REMOVED:
+				onChildLeft(client, event.getData());
+				break;
+			case CONNECTION_SUSPENDED:
+				break;
+			case CONNECTION_RECONNECTED:
+				break;
+			case CONNECTION_LOST:
+				break;
+			case INITIALIZED:
+				break;
+		}
+	}
+
+	/**
+	 * Handle the arrival of a container. This implementation will scan the existing streams
+	 * and determine if any modules should be deployed to the new container.
+	 *
+	 * @param client  curator client
+	 * @param data    node data for the container that arrived
+	 */
+	private void onChildAdded(CuratorFramework client, ChildData data) throws Exception {
+		Container container = new Container(Paths.stripPath(data.getPath()), mapBytesUtility.toMap(data.getData()));
+		String containerName = container.getName();
+		LOG.info("Container arrived: {}", containerName);
+
+		for (Iterator<Stream> streamIterator = new ChildPathIterator<Stream>(streamConverter, streams);
+				streamIterator.hasNext();) {
+			Stream stream = streamIterator.next();
+			for (Iterator<ModuleDescriptor> descriptorIterator = stream.getDeploymentOrderIterator();
+					descriptorIterator.hasNext();) {
+				ModuleDescriptor descriptor = descriptorIterator.next();
+				String group = descriptor.getGroup();
+
+				if (StringUtils.isEmpty(group) || container.getGroups().contains(group)) {
+					String streamName = descriptor.getStreamName();
+					String moduleType = descriptor.getModule().getType().toString();
+					String moduleName = descriptor.getModule().getName();
+					String moduleLabel = descriptor.getLabel();
+
+					// obtain all of the containers that have deployed this module
+					String streamPath = Paths.createPath(Paths.STREAMS, streamName, moduleType,
+							String.format("%s.%s", moduleName, moduleLabel));
+					List<String> containersForModule = client.getChildren().forPath(streamPath);
+					if (!containersForModule.contains(containerName)) {
+						// this container has not deployed this module; determine if it should
+						int moduleCount = descriptor.getCount();
+						if (moduleCount <= 0 || containersForModule.size() < moduleCount) {
+							// either the module has a count of 0 (therefore it should be deployed everywhere)
+							// or the number of containers that have deployed the module is less than the
+							// amount specified by the module descriptor
+							LOG.info("Deploying module {} to {}", moduleName, container);
+
+							client.create().creatingParentsIfNeeded().forPath(
+									Paths.createPath(Paths.DEPLOYMENTS, containerName,
+											String.format("%s.%s.%s.%s", streamName, moduleType, moduleName, moduleLabel)));
+
+							String path = Paths.createPath(Paths.STREAMS, streamName, moduleType,
+									String.format("%s.%s", moduleName, moduleLabel), containerName);
+
+							// todo: make timeout configurable
+							long timeout = System.currentTimeMillis() + 30000;
+							boolean deployed;
+							do {
+								Thread.sleep(10);
+								deployed = client.checkExists().forPath(path) != null;
+							}
+							while (!deployed && System.currentTimeMillis() < timeout);
+
+							if (!deployed) {
+								throw new IllegalStateException(String.format(
+										"Deployment of module %s to container %s timed out", moduleName, containerName));
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Handle the departure of a container. This will scan the list of modules deployed to
+	 * the departing container and redeploy them if required.
+	 *
+	 * @param client  curator client
+	 * @param data    node data for the container that departed
+	 */
+	private void onChildLeft(CuratorFramework client, ChildData data) {
+		// find all of the deployments for the container that left
+		String container = Paths.stripPath(data.getPath());
+		LOG.info("Container departed: {}", container);
+
+		try {
+			Map<String, Stream> streamMap = new HashMap<String, Stream>();
+			List<String> deployments = client.getChildren().forPath(Paths.createPath(Paths.DEPLOYMENTS, container));
+			for (String deployment : deployments) {
+				String[] parts = deployment.split("\\.");
+				String streamName = parts[0];
+				String moduleType = parts[1];
+				String moduleName = parts[2];
+				String moduleLabel = parts[3];
+
+				Stream stream = streamMap.get(streamName);
+				if (stream == null) {
+					stream = streamFactory.createStream(streamName, mapBytesUtility.toMap(
+							client.getData().forPath(Paths.createPath(Paths.STREAMS, streamName))));
+					streamMap.put(streamName, stream);
+				}
+				ModuleDescriptor moduleDescriptor = stream.getModuleDescriptor(moduleName, moduleType);
+				if (moduleDescriptor.getCount() > 0) {
+					// for now assume that just one redeployment is needed
+
+					// todo: refactor duplicate code from StreamListener
+					Iterator<Container> iterator = stream.getContainerMatcher()
+							.match(moduleDescriptor, containerRepository).iterator();
+
+					if (iterator.hasNext()) {
+						Container targetContainer = iterator.next();
+						String targetName = targetContainer.getName();
+
+						LOG.info("Redeploying module {} for stream {} to container {}",
+								moduleName, streamName, targetName);
+
+						client.create().creatingParentsIfNeeded().forPath(
+								Paths.createPath(Paths.DEPLOYMENTS, targetName,
+										String.format("%s.%s.%s.%s", streamName, moduleType, moduleName, moduleLabel)));
+
+						// todo: not going to bother verifying the redeployment for now
+					}
+					else {
+						// uh oh
+						LOG.warn("No containers available for redeployment of {} for stream {}", moduleName, streamName);
+					}
+				}
+				else {
+					StringBuilder builder = new StringBuilder();
+					String group = moduleDescriptor.getGroup();
+					builder.append("Module '").append(moduleName).append("' with label '")
+							.append(moduleLabel).append("' is targeted to all containers");
+					if (StringUtils.hasText(group)) {
+						builder.append(" belonging to group '").append(group).append('\'');
+					}
+					builder.append("; it does not need to be redeployed");
+
+					LOG.info(builder.toString());
+				}
+			}
+
+			// remove the deployments from the departed container
+			client.delete().deletingChildrenIfNeeded().forPath(Paths.createPath(Paths.DEPLOYMENTS, container));
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		catch (Exception e) {
+			throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
+		}
+	}
+
+	public class StreamConverter implements Converter<ChildData, Stream> {
+
+		@Override
+		public Stream convert(ChildData source) {
+			return streamFactory.createStream(Paths.stripPath(source.getPath()), mapBytesUtility.toMap(source.getData()));
+		}
+	}
+
+}

--- a/src/main/java/xdzk/server/ContainerListener.java
+++ b/src/main/java/xdzk/server/ContainerListener.java
@@ -145,7 +145,7 @@ public class ContainerListener implements PathChildrenCacheListener {
 					String moduleLabel = descriptor.getLabel();
 
 					// obtain all of the containers that have deployed this module
-					String streamPath = Paths.createPath(Paths.STREAMS, streamName, moduleType,
+					String streamPath = Paths.build(Paths.STREAMS, streamName, moduleType,
 							String.format("%s.%s", moduleName, moduleLabel));
 					List<String> containersForModule = client.getChildren().forPath(streamPath);
 					if (!containersForModule.contains(containerName)) {
@@ -158,10 +158,10 @@ public class ContainerListener implements PathChildrenCacheListener {
 							LOG.info("Deploying module {} to {}", moduleName, container);
 
 							client.create().creatingParentsIfNeeded().forPath(
-									Paths.createPath(Paths.DEPLOYMENTS, containerName,
+									Paths.build(Paths.DEPLOYMENTS, containerName,
 											String.format("%s.%s.%s.%s", streamName, moduleType, moduleName, moduleLabel)));
 
-							String path = Paths.createPath(Paths.STREAMS, streamName, moduleType,
+							String path = Paths.build(Paths.STREAMS, streamName, moduleType,
 									String.format("%s.%s", moduleName, moduleLabel), containerName);
 
 							// todo: make timeout configurable
@@ -198,7 +198,7 @@ public class ContainerListener implements PathChildrenCacheListener {
 
 		try {
 			Map<String, Stream> streamMap = new HashMap<String, Stream>();
-			List<String> deployments = client.getChildren().forPath(Paths.createPath(Paths.DEPLOYMENTS, container));
+			List<String> deployments = client.getChildren().forPath(Paths.build(Paths.DEPLOYMENTS, container));
 			for (String deployment : deployments) {
 				String[] parts = deployment.split("\\.");
 				String streamName = parts[0];
@@ -209,7 +209,7 @@ public class ContainerListener implements PathChildrenCacheListener {
 				Stream stream = streamMap.get(streamName);
 				if (stream == null) {
 					stream = streamFactory.createStream(streamName, mapBytesUtility.toMap(
-							client.getData().forPath(Paths.createPath(Paths.STREAMS, streamName))));
+							client.getData().forPath(Paths.build(Paths.STREAMS, streamName))));
 					streamMap.put(streamName, stream);
 				}
 				ModuleDescriptor moduleDescriptor = stream.getModuleDescriptor(moduleName, moduleType);
@@ -228,7 +228,7 @@ public class ContainerListener implements PathChildrenCacheListener {
 								moduleName, streamName, targetName);
 
 						client.create().creatingParentsIfNeeded().forPath(
-								Paths.createPath(Paths.DEPLOYMENTS, targetName,
+								Paths.build(Paths.DEPLOYMENTS, targetName,
 										String.format("%s.%s.%s.%s", streamName, moduleType, moduleName, moduleLabel)));
 
 						// todo: not going to bother verifying the redeployment for now
@@ -253,7 +253,7 @@ public class ContainerListener implements PathChildrenCacheListener {
 			}
 
 			// remove the deployments from the departed container
-			client.delete().deletingChildrenIfNeeded().forPath(Paths.createPath(Paths.DEPLOYMENTS, container));
+			client.delete().deletingChildrenIfNeeded().forPath(Paths.build(Paths.DEPLOYMENTS, container));
 		}
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();

--- a/src/main/java/xdzk/server/ContainerServer.java
+++ b/src/main/java/xdzk/server/ContainerServer.java
@@ -140,10 +140,11 @@ public class ContainerServer extends AbstractServer {
 	 * @param data    module data
 	 */
 	private void onChildAdded(CuratorFramework client, ChildData data) {
-		Map<String, String> attributes = mapBytesUtility.toMap(data.getData());
-		String streamName = attributes.get("stream");
-		String moduleType = attributes.get("type");
-		String moduleName = Paths.stripPath(data.getPath());
+		String deploymentPath = Paths.stripPath(data.getPath());
+		String[] split = deploymentPath.split("\\.");
+		String streamName = split[0];
+		String moduleType = split[1];
+		String moduleName = split[2];
 
 		LOG.info("Deploying module {} for stream {}", moduleName, streamName);
 
@@ -153,12 +154,12 @@ public class ContainerServer extends AbstractServer {
 
 		// todo: this is where we load the module
 
-		String path = Paths.createPath(Paths.STREAMS, streamName, moduleType, moduleName, getId());
+		String streamPath = Paths.createPath(Paths.STREAMS, streamName, moduleType, moduleName, getId());
 
 		try {
 			// this indicates that the container has deployed the module
 			client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL)
-					.forPath(path, mapBytesUtility.toByteArray(Collections.singletonMap("state", "deployed")));
+					.forPath(streamPath, mapBytesUtility.toByteArray(Collections.singletonMap("state", "deployed")));
 		}
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();

--- a/src/main/java/xdzk/server/ContainerServer.java
+++ b/src/main/java/xdzk/server/ContainerServer.java
@@ -116,7 +116,7 @@ public class ContainerServer extends AbstractServer {
 			Paths.ensurePath(client, Paths.DEPLOYMENTS);
 			Paths.ensurePath(client, Paths.CONTAINERS);
 
-			deployments = new PathChildrenCache(client, Paths.createPath(Paths.DEPLOYMENTS, this.getId()), true);
+			deployments = new PathChildrenCache(client, Paths.build(Paths.DEPLOYMENTS, this.getId()), true);
 			deployments.getListenable().addListener(deploymentListener);
 
 			String mxBeanName = ManagementFactory.getRuntimeMXBean().getName();
@@ -136,7 +136,7 @@ public class ContainerServer extends AbstractServer {
 			map.put("groups", builder.toString());
 
 			client.create().withMode(CreateMode.EPHEMERAL).forPath(
-					Paths.createPath(Paths.CONTAINERS, this.getId()),
+					Paths.build(Paths.CONTAINERS, this.getId()),
 					mapBytesUtility.toByteArray(map));
 
 			deployments.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
@@ -188,7 +188,7 @@ public class ContainerServer extends AbstractServer {
 
 		// todo: this is where we load the module
 
-		String streamPath = Paths.createPath(Paths.STREAMS, streamName, moduleType,
+		String streamPath = Paths.build(Paths.STREAMS, streamName, moduleType,
 				String.format("%s.%s", moduleName, moduleLabel), getId());
 
 		try {
@@ -226,16 +226,6 @@ public class ContainerServer extends AbstractServer {
 			LOG.debug("Path cache event: {}", event);
 			switch (event.getType()) {
 				case INITIALIZED:
-					// todo: when the cache is initialized the getInitialData
-					// collection will contain all the children - instead of
-					// issuing a deployment this should perhaps determine
-					// if a deployment is required.
-
-					// For now just (wrongly) assume that everything
-					// should be deployed.
-					for (ChildData data : event.getInitialData()) {
-						onChildAdded(client, data);
-					}
 					break;
 				case CHILD_ADDED:
 					onChildAdded(client, event.getData());

--- a/src/main/java/xdzk/server/ContainerServer.java
+++ b/src/main/java/xdzk/server/ContainerServer.java
@@ -139,7 +139,7 @@ public class ContainerServer extends AbstractServer {
 					Paths.createPath(Paths.CONTAINERS, this.getId()),
 					mapBytesUtility.toByteArray(map));
 
-			deployments.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
+			deployments.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
 
 			LOG.info("Started container {} with attributes: {} ", this.getId(), map);
 		}

--- a/src/main/java/xdzk/server/ContainerServer.java
+++ b/src/main/java/xdzk/server/ContainerServer.java
@@ -95,7 +95,7 @@ public class ContainerServer extends AbstractServer {
 			Paths.ensurePath(client, Paths.DEPLOYMENTS);
 			Paths.ensurePath(client, Paths.CONTAINERS);
 
-			deployments = new PathChildrenCache(client, Paths.DEPLOYMENTS + "/" + this.getId(), true);
+			deployments = new PathChildrenCache(client, Paths.createPath(Paths.DEPLOYMENTS, this.getId()), true);
 			deployments.getListenable().addListener(deploymentListener);
 
 			String mxBeanName = ManagementFactory.getRuntimeMXBean().getName();
@@ -145,16 +145,19 @@ public class ContainerServer extends AbstractServer {
 		String streamName = split[0];
 		String moduleType = split[1];
 		String moduleName = split[2];
+		String moduleLabel = split[3];
 
-		LOG.info("Deploying module {} for stream {}", moduleName, streamName);
+		LOG.info("Deploying module '{}' for stream '{}'", moduleName, streamName);
+		LOG.debug("streamName={}, moduleType={}, moduleName={}, moduleLabel={}", streamName, moduleType, moduleName, moduleLabel);
 
 		Module module = moduleRepository.loadModule(moduleName, Module.Type.valueOf(moduleType.toUpperCase()));
 
-		LOG.info("Loading module from {}", module.getUrl());
+		LOG.debug("Loading module from {}", module.getUrl());
 
 		// todo: this is where we load the module
 
-		String streamPath = Paths.createPath(Paths.STREAMS, streamName, moduleType, moduleName, getId());
+		String streamPath = Paths.createPath(Paths.STREAMS, streamName, moduleType,
+				String.format("%s.%s", moduleName, moduleLabel), getId());
 
 		try {
 			// this indicates that the container has deployed the module

--- a/src/main/java/xdzk/server/StreamListener.java
+++ b/src/main/java/xdzk/server/StreamListener.java
@@ -67,7 +67,8 @@ public class StreamListener implements PathChildrenCacheListener {
 	/**
 	 * Construct a StreamListener.
 	 *
-	 * @param containerRepository admin server that this listener is attached to
+	 * @param containerRepository repository to obtain container data
+	 * @param moduleRepository    repository to obtain module data
 	 */
 	public StreamListener(ContainerRepository containerRepository, ModuleRepository moduleRepository) {
 		this.containerRepository = containerRepository;
@@ -137,10 +138,9 @@ public class StreamListener implements PathChildrenCacheListener {
 	 * Prepare the new stream for deployment. This updates the ZooKeeper znode
 	 * for the stream by adding the following under {@code /xd/streams/[stream-name]}:
 	 * <ul>
-	 *     <li>{@code .../source/[module-name]}</li>
-	 *     <li>{@code .../processor0/[module-name]}</li>
-	 *     <li>{@code .../processor1/[module-name]}</li>
-	 *     <li>{@code .../sink/[module-name]}</li>
+	 *     <li>{@code .../source/[module-name.module-label]}</li>
+	 *     <li>{@code .../processor/[module-name.module-label]}</li>
+	 *     <li>{@code .../sink/[module-name.module-label]}</li>
 	 * </ul>
 	 * The children of these nodes will be ephemeral nodes written by the containers
 	 * that accept deployment of the modules.

--- a/src/main/java/xdzk/server/StreamListener.java
+++ b/src/main/java/xdzk/server/StreamListener.java
@@ -117,7 +117,7 @@ public class StreamListener implements PathChildrenCacheListener {
 	private void onChildAdded(CuratorFramework client, ChildData data) {
 		String streamName = Paths.stripPath(data.getPath());
 		Map<String, String> map = mapBytesUtility.toMap(data.getData());
-		Stream stream = streamFactory.createStream(streamName, map.get("definition"), map);
+		Stream stream = streamFactory.createStream(streamName, map);
 
 		LOG.info("Deploying stream {}", stream);
 

--- a/src/main/java/xdzk/server/StreamListener.java
+++ b/src/main/java/xdzk/server/StreamListener.java
@@ -151,11 +151,13 @@ public class StreamListener implements PathChildrenCacheListener {
 	private void prepareStream(CuratorFramework client, Stream stream) throws Exception {
 		for (Iterator<ModuleDescriptor> iterator = stream.getDeploymentOrderIterator(); iterator.hasNext();) {
 			ModuleDescriptor module = iterator.next();
+			String streamName = stream.getName();
+			String moduleType = module.getModule().getType().toString();
 			String moduleName = module.getModule().getName();
+			String moduleLabel = module.getLabel();
 
-			// TODO: the processors MUST be ordered! They are not right now
-			String path = Paths.createPath(Paths.STREAMS, stream.getName(),
-					module.getModule().getType().toString(), moduleName);
+			String path = Paths.createPath(Paths.STREAMS, streamName,
+					moduleType, String.format("%s.%s", moduleName, moduleLabel));
 
 			try {
 				client.create().creatingParentsIfNeeded().forPath(path);
@@ -181,6 +183,7 @@ public class StreamListener implements PathChildrenCacheListener {
 			String streamName = stream.getName();
 			String moduleType = module.getModule().getType().toString();
 			String moduleName = module.getModule().getName();
+			String moduleLabel = module.getLabel();
 			Map<Container, String> mapDeploymentStatus = new HashMap<Container, String>();
 
 			for (Container container : stream.getContainerMatcher().match(module, containerRepository)) {
@@ -188,10 +191,11 @@ public class StreamListener implements PathChildrenCacheListener {
 				try {
 					client.create().creatingParentsIfNeeded().forPath(
 							Paths.createPath(Paths.DEPLOYMENTS, containerName,
-									String.format("%s.%s.%s", streamName, moduleType, moduleName)));
+									String.format("%s.%s.%s.%s", streamName, moduleType, moduleName, moduleLabel)));
 
 					mapDeploymentStatus.put(container,
-							Paths.createPath(Paths.STREAMS, streamName, moduleType, moduleName, containerName));
+							Paths.createPath(Paths.STREAMS, streamName, moduleType,
+									String.format("%s.%s", moduleName, moduleLabel), containerName));
 				}
 				catch (KeeperException.NodeExistsException e) {
 					LOG.info("Module {} is already deployed to container {}", module, container);

--- a/src/main/java/xdzk/server/StreamListener.java
+++ b/src/main/java/xdzk/server/StreamListener.java
@@ -156,7 +156,7 @@ public class StreamListener implements PathChildrenCacheListener {
 			String moduleName = module.getModule().getName();
 			String moduleLabel = module.getLabel();
 
-			String path = Paths.createPath(Paths.STREAMS, streamName,
+			String path = Paths.build(Paths.STREAMS, streamName,
 					moduleType, String.format("%s.%s", moduleName, moduleLabel));
 
 			try {
@@ -190,11 +190,11 @@ public class StreamListener implements PathChildrenCacheListener {
 				String containerName = container.getName();
 				try {
 					client.create().creatingParentsIfNeeded().forPath(
-							Paths.createPath(Paths.DEPLOYMENTS, containerName,
+							Paths.build(Paths.DEPLOYMENTS, containerName,
 									String.format("%s.%s.%s.%s", streamName, moduleType, moduleName, moduleLabel)));
 
 					mapDeploymentStatus.put(container,
-							Paths.createPath(Paths.STREAMS, streamName, moduleType,
+							Paths.build(Paths.STREAMS, streamName, moduleType,
 									String.format("%s.%s", moduleName, moduleLabel), containerName));
 				}
 				catch (KeeperException.NodeExistsException e) {
@@ -212,6 +212,7 @@ public class StreamListener implements PathChildrenCacheListener {
 					if (client.checkExists().forPath(entry.getValue()) != null) {
 						iteratorStatus.remove();
 					}
+					Thread.sleep(10);
 				}
 			}
 			while (!mapDeploymentStatus.isEmpty() && System.currentTimeMillis() < timeout);

--- a/src/test/java/demo/StreamWriter.java
+++ b/src/test/java/demo/StreamWriter.java
@@ -67,7 +67,7 @@ public class StreamWriter {
 				attributes.put("definition", definition);
 			}
 
-			client.create(Paths.createPathWithNamespace(Paths.STREAMS, name),
+			client.create(Paths.buildWithNamespace(Paths.STREAMS, name),
 					utility.toByteArray(attributes),
 					ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 		}

--- a/src/test/java/demo/StreamWriter.java
+++ b/src/test/java/demo/StreamWriter.java
@@ -45,13 +45,15 @@ public class StreamWriter {
 
 		// stream with deployment manifest
 		Map<String, String> attributes = new HashMap<String, String>();
-		attributes.put("module.http.group", "all");
-		attributes.put("module.file.group", "all");
+		attributes.put("module.http.count", "0");
+		attributes.put("module.file.count", "0");
 		createStream(zk, "everywhere", "http | file", attributes);
 
 		// stream targeted to group
 		attributes = new HashMap<String, String>();
 		attributes.put("module.hdfs.group", "hdfs");
+		attributes.put("module.http.group", "http");
+
 		createStream(zk, "hdfs-writer", "http | hdfs", attributes);
 	}
 

--- a/src/test/java/demo/StreamWriter.java
+++ b/src/test/java/demo/StreamWriter.java
@@ -48,6 +48,11 @@ public class StreamWriter {
 		attributes.put("module.http.group", "all");
 		attributes.put("module.file.group", "all");
 		createStream(zk, "everywhere", "http | file", attributes);
+
+		// stream targeted to group
+		attributes = new HashMap<String, String>();
+		attributes.put("module.hdfs.group", "hdfs");
+		createStream(zk, "hdfs-writer", "http | hdfs", attributes);
 	}
 
 	private static void createStream(ZooKeeper client, String name, String definition, Map<String, String> attributes) {

--- a/src/test/java/xdzk/admin/AdminContainerObserverTest.java
+++ b/src/test/java/xdzk/admin/AdminContainerObserverTest.java
@@ -163,10 +163,10 @@ public class AdminContainerObserverTest {
 			// a break point should be set in here to pause execution of
 			// the test while another debug session is launched to attach
 			// to the admin server.
-			adminServer = launch(AdminApplication.class, true, zkAddress);
-			container1 = launch(ContainerApplication.class, false, zkAddress);
-			container2 = launch(ContainerApplication.class, false, zkAddress);
-			container3 = launch(ContainerApplication.class, false, zkAddress);
+			adminServer = launch(AdminApplication.class, true, "--zk=" + zkAddress);
+			container1 = launch(ContainerApplication.class, false, "--zk=" + zkAddress);
+			container2 = launch(ContainerApplication.class, false, "--zk=" + zkAddress);
+			container3 = launch(ContainerApplication.class, false, "--zk=" + zkAddress);
 
 			Eventually.assertThat(eventually(invoking(this).getCurrentContainers(adminServer).size()), is(3),
 					90, TimeUnit.SECONDS);

--- a/src/test/java/xdzk/cluster/DeploymentManifestMatcherTest.java
+++ b/src/test/java/xdzk/cluster/DeploymentManifestMatcherTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdzk.cluster;
+
+import org.junit.Test;
+import xdzk.core.Module;
+import xdzk.core.ModuleDescriptor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link DeploymentManifestMatcher}.
+ *
+ * @author Patrick Peralta
+ */
+public class DeploymentManifestMatcherTest {
+
+	/**
+	 * Test container matching for a module descriptor that specifies one containers.
+	 */
+	@Test
+	public void testOneModule() {
+		DeploymentManifestMatcher matcher = new DeploymentManifestMatcher();
+
+		ModuleDescriptor descriptor = newModuleDescriptor(null, 1);
+
+		Collection<Container> one = matcher.match(descriptor, new ContainerRepositoryBuilder().add(1).build());
+		assertEquals(1, one.size());
+		assertEquals(0, one.iterator().next().getGroups().size());
+
+		Collection<Container> five = matcher.match(descriptor, new ContainerRepositoryBuilder().add(5).build());
+		assertEquals(1, five.size());
+	}
+
+	/**
+	 * Test container matching for a module descriptor that specifies two containers.
+	 */
+	@Test
+	public void testTwoModules() {
+		DeploymentManifestMatcher matcher = new DeploymentManifestMatcher();
+
+		ModuleDescriptor descriptor = newModuleDescriptor(null, 2);
+
+		Collection<Container> one = matcher.match(descriptor, new ContainerRepositoryBuilder().add(1).build());
+		assertEquals(1, one.size());
+		assertEquals(0, one.iterator().next().getGroups().size());
+
+		Collection<Container> five = matcher.match(descriptor, new ContainerRepositoryBuilder().add(5).build());
+		assertEquals(2, five.size());
+	}
+
+	/**
+	 * Test container matching for a module descriptor that specifies all containers.
+	 */
+	@Test
+	public void testAll() {
+		DeploymentManifestMatcher matcher = new DeploymentManifestMatcher();
+
+		ModuleDescriptor descriptor = newModuleDescriptor(null, 0);
+
+		Collection<Container> one = matcher.match(descriptor, new ContainerRepositoryBuilder().add(1).build());
+		assertEquals(1, one.size());
+		assertEquals(0, one.iterator().next().getGroups().size());
+
+		Collection<Container> five = matcher.match(descriptor, new ContainerRepositoryBuilder().add(5).build());
+		assertEquals(5, five.size());
+	}
+
+	/**
+	 * Test container matching for a module descriptor that specifies all containers
+	 * in a group.
+	 */
+	@Test
+	public void testGroup() {
+		DeploymentManifestMatcher matcher = new DeploymentManifestMatcher();
+
+		ModuleDescriptor descriptor = newModuleDescriptor("blue", 0);
+		Collection<Container> containers = matcher.match(descriptor,
+				new ContainerRepositoryBuilder().add(5, "blue").add(5, "red").build());
+
+		assertEquals(5, containers.size());
+		for (Container container : containers) {
+			assertTrue(container.getGroups().contains("blue"));
+		}
+	}
+
+	/**
+	 * Test container matching for a module descriptor that specifies five containers
+	 * in a group.
+	 */
+	@Test
+	public void testFiveGroup() {
+		DeploymentManifestMatcher matcher = new DeploymentManifestMatcher();
+
+		ModuleDescriptor descriptor = newModuleDescriptor("blue", 5);
+		Collection<Container> containers = matcher.match(descriptor,
+				new ContainerRepositoryBuilder().add(10, "blue").add(10, "red").build());
+
+		assertEquals(5, containers.size());
+		for (Container container : containers) {
+			assertTrue(container.getGroups().contains("blue"));
+		}
+	}
+
+	/**
+	 * Test container matching where the module descriptor indicates more
+	 * containers than are available.
+	 */
+	@Test
+	public void testMoreModulesThanContainers() {
+		DeploymentManifestMatcher matcher = new DeploymentManifestMatcher();
+		ModuleDescriptor descriptor = newModuleDescriptor(null, 20);
+
+		Collection<Container> containers = matcher.match(descriptor, new ContainerRepositoryBuilder().add(5).build());
+		assertEquals(5, containers.size());
+	}
+
+	/**
+	 * Test multiple uses of a {@link DeploymentManifestMatcher}. It is expected
+	 * that multiple invocations will return different container instances if possible
+	 * in a round robin fashion.
+	 */
+	@Test
+	public void testMultipleIterations() {
+		DeploymentManifestMatcher matcher = new DeploymentManifestMatcher();
+		ModuleDescriptor descriptor = newModuleDescriptor(null, 5);
+		ContainerRepository repository = new ContainerRepositoryBuilder().add(20).build();
+
+		Collection<Container> first = matcher.match(descriptor, repository);
+		assertEquals(5, first.size());
+
+		Collection<Container> second = matcher.match(descriptor, repository);
+		assertEquals(5, second.size());
+
+		for (Container container : first) {
+			assertFalse(second.contains(container));
+		}
+		for (Container container : second) {
+			assertFalse(first.contains(container));
+		}
+
+		assertEquals(5, matcher.match(descriptor, repository).size());
+		assertEquals(5, matcher.match(descriptor, repository).size());
+
+		Collection<Container> last = matcher.match(descriptor, repository);
+		assertEquals(5, last.size());
+		assertEquals(first, last);
+	}
+
+	/**
+	 * Create a new {@link ModuleDescriptor} for testing.
+	 *
+	 * @param group  group for module deployment; may be null
+	 * @param count  number of instances requested for a module
+	 *
+	 * @return new module descriptor
+	 */
+	protected ModuleDescriptor newModuleDescriptor(String group, int count) {
+		Module module = new Module("file", Module.Type.SOURCE, "file:///file");
+		return new ModuleDescriptor(module, "file", "file0", 0, group, count);
+	}
+
+	/**
+	 * Create a new instance of a {@link Container}.
+	 *
+	 * @param groups comma delimited list of groups this container
+	 *               belongs to; may be null
+	 *
+	 * @return new instance of container
+	 */
+	protected Container newContainer(String groups) {
+		return new Container(UUID.randomUUID().toString(),
+				groups == null
+						? Collections.<String, String>emptyMap()
+						: Collections.singletonMap("groups", groups));
+	}
+
+	/**
+	 * Builder object for {@link ContainerRepository}.
+	 */
+	class ContainerRepositoryBuilder {
+		/**
+		 * Map of group (comma delimited) string to number of container instances.
+		 */
+		Map<String, Integer> groupCounts = new HashMap<String, Integer>();
+
+		/**
+		 * Number of containers with no group.
+		 */
+		int noGroup;
+
+		/**
+		 * Add the provided number of non group containers to the container repository.
+		 *
+		 * @param count number of containers
+		 *
+		 * @return this builder
+		 */
+		public ContainerRepositoryBuilder add(int count) {
+			noGroup += count;
+			return this;
+		}
+
+		/**
+		 * Add the provided number of containers that belong to the provided string of
+		 * groups.
+		 *
+		 * @param count   number of containers
+		 * @param groups  comma delimited list of groups these containers belong to
+		 *
+		 * @return this builder
+		 */
+		public ContainerRepositoryBuilder add(int count, String groups) {
+			groupCounts.put(groups, count);
+			return this;
+		}
+
+		/**
+		 * Return a new instance of {@link ContainerRepository}.
+		 *
+		 * @return new instance of ContainerRepository
+		 */
+		public ContainerRepository build() {
+			final List<Container> containers = new ArrayList<Container>();
+			for (int i = 0; i < noGroup; i++) {
+				containers.add(newContainer(null));
+			}
+			for (Map.Entry<String, Integer> entry : groupCounts.entrySet()) {
+				for (int i = 0; i < entry.getValue(); i++) {
+					containers.add(newContainer(entry.getKey()));
+				}
+			}
+
+			return new ContainerRepository() {
+				@Override
+				public Iterator<Container> getContainerIterator() {
+					return containers.iterator();
+				}
+			};
+		}
+
+	}
+
+}

--- a/src/test/java/xdzk/core/StreamTest.java
+++ b/src/test/java/xdzk/core/StreamTest.java
@@ -40,8 +40,8 @@ public class StreamTest {
 
 		String[] moduleNames = {"log", "time"};
 		for (String moduleName : moduleNames) {
-			ModuleDescriptor module = iterator.next();
-			assertEquals(moduleName, module.getModule().getName());
+			ModuleDescriptor descriptor = iterator.next();
+			assertEquals(moduleName, descriptor.getModule().getName());
 		}
 
 		assertFalse(iterator.hasNext());
@@ -68,8 +68,8 @@ public class StreamTest {
 
 		String[] moduleNames = {"log", "filter", "transform", "http"};
 		for (String moduleName : moduleNames) {
-			ModuleDescriptor module = iterator.next();
-			assertEquals(moduleName, module.getModule().getName());
+			ModuleDescriptor descriptor = iterator.next();
+			assertEquals(moduleName, descriptor.getModule().getName());
 		}
 
 		assertFalse(iterator.hasNext());

--- a/src/test/java/xdzk/core/StreamTest.java
+++ b/src/test/java/xdzk/core/StreamTest.java
@@ -34,13 +34,13 @@ public class StreamTest {
 		Stream stream = streamFactory.createStream("ticktock", "time | log", null);
 
 		assertEquals("ticktock", stream.getName());
-		Iterator<Module> iterator = stream.getDeploymentOrderIterator();
+		Iterator<ModuleDescriptor> iterator = stream.getDeploymentOrderIterator();
 		assertTrue(iterator.hasNext());
 
 		String[] moduleNames = {"log", "time"};
 		for (String moduleName : moduleNames) {
-			Module module = iterator.next();
-			assertEquals(moduleName, module.getName());
+			ModuleDescriptor module = iterator.next();
+			assertEquals(moduleName, module.getModule().getName());
 		}
 
 		assertFalse(iterator.hasNext());
@@ -62,13 +62,13 @@ public class StreamTest {
 		Stream stream = streamFactory.createStream("fancy-http", "http | transform | filter | log", null);
 
 		assertEquals("fancy-http", stream.getName());
-		Iterator<Module> iterator = stream.getDeploymentOrderIterator();
+		Iterator<ModuleDescriptor> iterator = stream.getDeploymentOrderIterator();
 		assertTrue(iterator.hasNext());
 
 		String[] moduleNames = {"log", "filter", "transform", "http"};
 		for (String moduleName : moduleNames) {
-			Module module = iterator.next();
-			assertEquals(moduleName, module.getName());
+			ModuleDescriptor module = iterator.next();
+			assertEquals(moduleName, module.getModule().getName());
 		}
 
 		assertFalse(iterator.hasNext());

--- a/src/test/java/xdzk/core/StreamTest.java
+++ b/src/test/java/xdzk/core/StreamTest.java
@@ -18,6 +18,7 @@ package xdzk.core;
 
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -31,7 +32,7 @@ public class StreamTest {
 	public void testSimpleStream() {
 		ModuleRepository moduleRepository = new StubModuleRepository();
 		StreamFactory streamFactory = new StreamFactory(moduleRepository);
-		Stream stream = streamFactory.createStream("ticktock", "time | log", null);
+		Stream stream = streamFactory.createStream("ticktock", Collections.singletonMap("definition", "time | log"));
 
 		assertEquals("ticktock", stream.getName());
 		Iterator<ModuleDescriptor> iterator = stream.getDeploymentOrderIterator();
@@ -58,8 +59,8 @@ public class StreamTest {
 	public void testProcessorStream() {
 		ModuleRepository moduleRepository = new StubModuleRepository();
 		StreamFactory streamFactory = new StreamFactory(moduleRepository);
-
-		Stream stream = streamFactory.createStream("fancy-http", "http | transform | filter | log", null);
+		Stream stream = streamFactory.createStream("fancy-http",
+				Collections.singletonMap("definition", "http | transform | filter | log"));
 
 		assertEquals("fancy-http", stream.getName());
 		Iterator<ModuleDescriptor> iterator = stream.getDeploymentOrderIterator();


### PR DESCRIPTION
- Introduced stream deployment manifest (key/value pairs in JSON format)
- Added support for module labels
- Containers can be configured for group membership via command line option `--groups=group_a, group_b`
- Module deployments can be targeted to groups and/or number of containers. A count of 0 means deploy to the entire group, or if group is omitted to all containers
- Also includes some test fixes due to Boot migration

This PR addresses the following issues
- https://github.com/markfisher/xdzk/issues/14
- https://github.com/markfisher/xdzk/issues/18
- https://github.com/markfisher/xdzk/issues/19
- https://github.com/markfisher/xdzk/issues/21
